### PR TITLE
ci: align project board actions with vega repo

### DIFF
--- a/.github/workflows/add_issues_to_project.yml
+++ b/.github/workflows/add_issues_to_project.yml
@@ -1,0 +1,26 @@
+---
+
+name: Add Issues To Project Board
+
+"on":
+  issues:
+    types: [opened]
+
+jobs:
+  add_issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add issue project board
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
+          PROJECT_ID: ${{ secrets.CORE_PROJECT_ID }}
+          ISSUE_ID: ${{ github.event.issue.node_id }}
+        run: |
+          gh api graphql -f query='
+            mutation($project:ID!, $issue:ID!) {
+              addProjectNextItem(input: {projectId: $project, contentId: $issue}) {
+                projectNextItem {
+                  id
+                }
+              }
+            }' -f project=$PROJECT_ID -f issue=$ISSUE_ID --jq '.data.addProjectNextItem.projectNextItem.id'

--- a/.github/workflows/project_manage.yml
+++ b/.github/workflows/project_manage.yml
@@ -1,0 +1,342 @@
+---
+
+name: Manage Project Board
+
+"on":
+  pull_request:
+    branches: [main]
+    types: [edited, synchronize, opened, reopened, labeled, unlabeled, ready_for_review, review_requested]
+
+jobs:
+  verify-conventional-commits:
+    if: startsWith(github.head_ref, 'renovate/') != true
+    name: Verify Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Commitsar conventional commits check
+        uses: aevea/commitsar@v0.18.0
+
+  verify-linked-issue:
+    if: |
+      ((startsWith(github.head_ref, 'renovate/') != true) && (contains(github.event.*.name, 'labeled')
+      || contains(github.event.*.name, 'unlabeled') || !contains(github.event.pull_request.labels.*.name, 'no-changelog') == true))
+    runs-on: ubuntu-latest
+    name: Verify Linked Issue
+    steps:
+      - name: Verify linked issue
+        uses: hattan/verify-linked-issue-action@v1.1.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  verify-changelog-updated:
+    if: |
+      ((startsWith(github.head_ref, 'renovate/') != true) && (contains(github.event.*.name, 'labeled')
+      || contains(github.event.*.name, 'unlabeled') || !contains(github.event.pull_request.labels.*.name, 'no-changelog') == true)
+      && (github.event.pull_request.draft != true))
+    name: Verify CHANGELOG Updated
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Check changelog entry
+        uses: Zomzog/changelog-checker@v1.2.0
+        with:
+          fileName: CHANGELOG.md
+          noChangelogLabel: "no-changelog"
+          checkNotification: Simple
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  skip-changelog-and-issue-checks:
+    if: |
+      ((startsWith(github.head_ref, 'renovate/') != true) && (contains(github.event.*.name, 'labeled')
+      || contains(github.event.*.name, 'unlabeled') || contains(github.event.pull_request.labels.*.name, 'no-changelog') == true)
+      && (github.event.pull_request.draft != true))
+    name: Skip Changelog And Issue Checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get project data
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
+          ORGANIZATION: vegaprotocol
+          PROJECT_NUMBER: 106
+          # yamllint disable rule:line-length
+        run: |
+          gh api graphql -f query='
+            query($org: String!, $number: Int!) {
+              organization(login: $org){
+                projectNext(number: $number) {
+                  id
+                  fields(first:20) {
+                    nodes {
+                      id
+                      name
+                      settings
+                    }
+                  }
+                }
+              }
+            }' -f org=$ORGANIZATION -F number=$PROJECT_NUMBER > project_data.json
+          echo 'PROJECT_ID='$(jq '.data.organization.projectNext.id' project_data.json) >> $GITHUB_ENV
+          echo 'STATUS_FIELD_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "Status") | .id' project_data.json) >> $GITHUB_ENV
+          echo 'PR_REVIEW_OPTION_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "Status") |.settings | fromjson.options[] | select(.name=="Waiting Review") |.id' project_data.json) >> $GITHUB_ENV
+          echo 'ITER_FIELD_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "Sprint") | .id' project_data.json) >> $GITHUB_ENV
+          echo 'ITER_OPTION_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "Sprint") |.settings | fromjson.configuration.iterations[0] | .id' project_data.json) >> $GITHUB_ENV
+# yamllint enable rule:line-length
+
+      - name: Add pr to project
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
+          PR_ID: ${{ github.event.pull_request.node_id }}
+        run: |
+          item_id="$( gh api graphql -f query='
+            mutation($project:ID!, $pr:ID!) {
+              addProjectNextItem(input: {projectId: $project, contentId: $pr}) {
+                projectNextItem {
+                  id
+                }
+              }
+            }' -f project=$PROJECT_ID -f pr=$PR_ID --jq '.data.addProjectNextItem.projectNextItem.id')"
+          echo 'ITEM_ID='$item_id >> $GITHUB_ENV
+
+      - name: Set pr project status fields
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
+        run: |
+          gh api graphql -f query='
+            mutation (
+              $project: ID!
+              $item: ID!
+              $status_field: ID!
+              $status_value: String!
+              $iteration_field: ID!
+              $iteration_value: String!
+            ) {
+              set_status: updateProjectNextItemField(input: {
+                projectId: $project
+                itemId: $item
+                fieldId: $status_field
+                value: $status_value
+              }) {
+                projectNextItem {
+                  id
+                  }
+              }
+              set_iteration: updateProjectNextItemField(input: {
+                projectId: $project
+                itemId: $item
+                fieldId: $iteration_field
+                value: $iteration_value
+              }) {
+                projectNextItem {
+                  id
+                }
+              }
+            }' -f project=$PROJECT_ID \
+              -f item=$ITEM_ID \
+              -f status_field=$STATUS_FIELD_ID \
+              -f status_value=${{ env.PR_REVIEW_OPTION_ID }} \
+              -f iteration_field=$ITER_FIELD_ID \
+              -f iteration_value=${{ env.ITER_OPTION_ID }}
+
+  update-issues-when-pr-linked:
+    needs: verify-linked-issue
+    name: Update Issue When PR Linked
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      checks: write
+      contents: write
+      issues: write
+      pull-requests: write
+      repository-projects: write
+      statuses: write
+    steps:
+      - name: Get project data
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
+          ORGANIZATION: vegaprotocol
+          PROJECT_NUMBER: 106
+          # yamllint disable rule:line-length
+        run: |
+          gh api graphql -f query='
+            query($org: String!, $number: Int!) {
+              organization(login: $org){
+                projectNext(number: $number) {
+                  id
+                  fields(first:20) {
+                    nodes {
+                      id
+                      name
+                      settings
+                    }
+                  }
+                }
+              }
+            }' -f org=$ORGANIZATION -F number=$PROJECT_NUMBER > project_data1.json
+          echo 'PROJECT_ID='$(jq '.data.organization.projectNext.id' project_data1.json) >> $GITHUB_ENV
+          echo 'STATUS_FIELD_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "Status") | .id' project_data1.json) >> $GITHUB_ENV
+          # yamllint disable-line rule:line-length
+          echo 'INPROG_OPTION_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "Status") |.settings | fromjson.options[] | select(.name=="In Progress") |.id' project_data1.json) >> $GITHUB_ENV
+          echo 'REVIEW_OPTION_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "Status") |.settings | fromjson.options[] | select(.name=="Waiting Review") |.id' project_data1.json) >> $GITHUB_ENV
+          echo 'ITER_FIELD_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "Sprint") | .id' project_data1.json) >> $GITHUB_ENV
+          # yamllint disable-line rule:line-length
+          echo 'ITER_OPTION_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "Sprint") |.settings | fromjson.configuration.iterations[0] | .id' project_data1.json) >> $GITHUB_ENV
+# yamllint enable rule:line-length
+
+      - name: Get linked issue nodeid
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          # yamllint disable rule:line-length
+        run: |
+          gh api graphql -f query='
+            query($pr_url: URI!) {
+              resource(url: $pr_url) {
+                ... on PullRequest {
+                  closingIssuesReferences(first: 1) {
+                    nodes {
+                      id
+                      number
+                      projectNextItems(first: 5) {
+                        edges {
+                          node {
+                            id
+                            project {
+                              id
+                              number
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }'  -f pr_url=$PR_URL > linked_issue_data.json
+            echo 'LINKED_ISSUE='$(jq -r '.data.resource.closingIssuesReferences.nodes[] | .id' linked_issue_data.json) >> $GITHUB_ENV
+            echo 'ISSUES_PROJ_ID='$(jq '.data.resource.closingIssuesReferences.nodes[] | .projectNextItems.edges[].node |select(.project.number == 106) | .id' linked_issue_data.json) >> $GITHUB_ENV
+# yamllint enable rule:line-length
+
+      - name: Get issues current status
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
+        run: |
+          gh api graphql -f query='
+            query ($issue_proj_id: ID!) {
+              node(id: $issue_proj_id) {
+                ... on ProjectNextItem {
+                  fieldValues(first: 10) {
+                    nodes {
+                      value
+                      projectField {
+                        name
+                      }
+                    }
+                  }
+                }
+              }
+            }' -f issue_proj_id=$ISSUES_PROJ_ID > current_col.json
+            echo 'CURRENT_COL='$(jq '.data.node.fieldValues.nodes[] | select(.projectField.name == "Status") | .value' current_col.json) >> $GITHUB_ENV
+            echo 'CURRENT_ITER='$(jq '.data.node.fieldValues.nodes[] | select(.projectField.name == "Sprint") | .value' current_col.json) >> $GITHUB_ENV
+
+      - name: Add issue to the project
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
+        run: |
+          item_id="$( gh api graphql -f query='
+            mutation($project:ID!, $issue:ID!) {
+              addProjectNextItem(input: {projectId: $project, contentId: $issue}) {
+                projectNextItem {
+                  id
+                }
+              }
+            }' -f project=$PROJECT_ID -f issue=$LINKED_ISSUE --jq '.data.addProjectNextItem.projectNextItem.id')"
+          echo 'ITEM_ID='$item_id >> $GITHUB_ENV
+
+      - name: Set wip issue project status fields
+        if: (env.CURRENT_COL != env.REVIEW_OPTION_ID)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
+        run: |
+          gh api graphql -f query='
+            mutation (
+              $project: ID!
+              $item: ID!
+              $status_field: ID!
+              $status_value: String!
+              $iteration_field: ID!
+              $iteration_value: String!
+            ) {
+              set_status: updateProjectNextItemField(input: {
+                projectId: $project
+                itemId: $item
+                fieldId: $status_field
+                value: $status_value
+              }) {
+                projectNextItem {
+                  id
+                  }
+              }
+              set_iteration: updateProjectNextItemField(input: {
+                projectId: $project
+                itemId: $item
+                fieldId: $iteration_field
+                value: $iteration_value
+              }) {
+                projectNextItem {
+                  id
+                }
+              }
+            }' -f project=$PROJECT_ID \
+              -f item=$ITEM_ID \
+              -f status_field=$STATUS_FIELD_ID \
+              -f status_value=${{ env.INPROG_OPTION_ID }} \
+              -f iteration_field=$ITER_FIELD_ID \
+              -f iteration_value=${{ env.ITER_OPTION_ID }}
+
+      - name: Set in review issue project status fields
+        if: (env.CURRENT_COL == env.REVIEW_OPTION_ID)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
+        run: |
+          gh api graphql -f query='
+            mutation (
+              $project: ID!
+              $item: ID!
+              $status_field: ID!
+              $status_value: String!
+              $iteration_field: ID!
+              $iteration_value: String!
+            ) {
+              set_status: updateProjectNextItemField(input: {
+                projectId: $project
+                itemId: $item
+                fieldId: $status_field
+                value: $status_value
+              }) {
+                projectNextItem {
+                  id
+                  }
+              }
+              set_iteration: updateProjectNextItemField(input: {
+                projectId: $project
+                itemId: $item
+                fieldId: $iteration_field
+                value: $iteration_value
+              }) {
+                projectNextItem {
+                  id
+                }
+              }
+            }' -f project=$PROJECT_ID \
+              -f item=$ITEM_ID \
+              -f status_field=$STATUS_FIELD_ID \
+              -f status_value=${{ env.REVIEW_OPTION_ID }} \
+              -f iteration_field=$ITER_FIELD_ID \
+              -f iteration_value=${{ env.ITER_OPTION_ID }}

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -1,0 +1,70 @@
+# Process
+
+This document is to describe the internal process that the Vega project core protocol team uses for issue and pull request management and the development workflow.
+
+## Table of contents
+ * [Project Boards](#project-boards)
+ * [Workflow](#workflow)
+ * [Reviews](#reviews)
+
+## Project Boards
+
+Work is primarily driven by the ~3 month [milestone planning](https://github.com/vegaprotocol/specs-internal/tree/master/milestones) and split into 2 week sprints for the team have short term delivery focus. The Core Protocol [Kanban Board](https://github.com/vegaprotocol/vega/projects?type=beta) uses two GitHub Actions to automate some of the project management:
+
+### [Add Issues To Project Board](https://github.com/vegaprotocol/vega/tree/develop/.github/workflows/add_issue_to_project.yml) GitHub Action
+
+Any issue that is opened in the following repos will be placed in the Sprint Backlog on the [Core Kanban Board](https://github.com/orgs/vegaprotocol/projects/106/views/27) set as `no:status` in order for it be reviewed, refined and planned into a Sprint.
+
+### [Manage Project Board](https://github.com/vegaprotocol/vega/tree/develop/.github/workflows/project_manage.yml) GitHub Action
+
+For any pull request to be merged into develop or main/master matching a pull request action type specified in the GitHub Action the following jobs are run. The `no-changelog` label can be applied to the pull request for times when we do not need a changelog entry or a verifiable linked issue.
+
+> ℹ️ Note: Adding the `no-changelog` label to a pull request should only be done for smaller (> 1 hour) tasks that do not require a changelog entry or a verifiable linked issue.
+
+#### Verify Conventional Commits Job
+
+This job will run on all pull requests that are not created by the Renovate Bot. A [third party GitHub Action](https://commitsar.aevea.ee/usage/github/) checks sure all commit messages adhere to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/) specification.
+
+#### Verify Linked Issue Job
+
+This job will run on all pull requests that are not created by the Renovate Bot and that do not have the `no-changelog` label applied. Adding and removing this label from any pull request will have the following effect:
+
+* **adding** the `no-changelog` label will **stop this job from running**
+* **removing** the `no-changelog` label will **start running this job**
+
+A [third party GitHub action](https://github.com/hattan/verify-linked-issue-action) makes sure all pull requests that meet the above criteria have a linked issue.
+
+> ℹ️ Note: Linked issues must have a space after the issue number in the first comment of the PR i.e. “Closes #123 “. For further details on linking keywords see the [GitHub docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
+
+#### Verify CHANGELOG Updated Job
+
+This job will run on all **non-draft** pull requests that are not created by the Renovate Bot. Adding and removing the `no-changelog` label from a non-draft pull request will have the following effect:
+
+* **adding** the `no-changelog` label will **stop this job from running**
+* **removing** the `no-changelog` label will **start running this job**
+
+A [third party GitHub action](https://github.com/Zomzog/changelog-checker) makes sure all pull requests that meet the above criteria have a change to the changelog in the files changed.
+
+> Note: For further details on good practice for CHANGELOG entries see the [`keepachangelog` docs](https://keepachangelog.com/en/1.0.0/)
+
+#### Update Issue When PR Linked
+
+This job will only run if the [Verify Linked Issue](# Verify-Linked-Issue-Job) job has run successfully. It has a number of steps that use GitHub GraphQL queries to retrieve and update data:
+
+1. **Get the project data**: gets variables such as the current sprint and specific Kanban board column names.
+1. **Get linked issue `nodeid`**: gets the `nodeID` of the **most recent** issue that has been linked to the pull request.
+1. **Add issue to project**: adds the linked issue to the project board, if not already present.
+1. **Set issue project status fields**: updates the issue fields; sets the status to `In Progress` and sprint to `@current`. If the issue is already in `Waiting Review` the issue will remain with this status.
+
+#### Skip Changelog And Issue Checks
+
+This job will run on all **non-draft** pull requests that are not created by the Renovate Bot. Adding and removing the `no-changelog` label from a non-draft pull request will have the following effect:
+
+* **adding** the `no-changelog` label will **start running this job**
+* **removing** the `no-changelog` label will **stop this job from running**
+
+This job has a number of steps that use GitHub GraphQL queries to retrieve and update data:
+
+1. **Get the project data**: gets variables such as the current sprint and specific Kanban board column names.
+1. **Add `pr` to project**: adds the pull request to the project board so the team knows it exists.
+1. **Set `pr` project status fields**: updates the issue fields; sets the status to `Waiting Review` and sprint to `@current`.


### PR DESCRIPTION
Aligns the project board GitHub actions with the vega repo

adds
- add new issues to project board action
- conventional commits checks
- board automations (phase1)
- start of the PROCESS.md informaton