### PR TITLE
print out the spec of the new node once successfully started

### DIFF
--- a/cmd/nodes_add.go
+++ b/cmd/nodes_add.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"code.vegaprotocol.io/vegacapsule/generator"
@@ -43,7 +44,17 @@ var nodesAddCmd = &cobra.Command{
 
 		}
 
-		return networkState.Persist()
+		if err := networkState.Persist(); err != nil {
+			return fmt.Errorf("failed to persist network: %w", err)
+		}
+
+		newNodeJson, err := json.MarshalIndent(newNodeSet, "", "\t")
+		if err != nil {
+			return fmt.Errorf("failed to marshal validators info: %w", err)
+		}
+
+		fmt.Println(string(newNodeJson))
+		return nil
 	},
 }
 


### PR DESCRIPTION
It would be useful for the system tests to know the node that was created when calling `vegacapsule nodes add`, so we now print out the JSON details of it once it has been successfully added.