### PR TITLE
ci: allow new issues to go to core or devops project boards

### DIFF
--- a/.github/workflows/add_issues_to_project.yml
+++ b/.github/workflows/add_issues_to_project.yml
@@ -10,7 +10,8 @@ jobs:
   add_issue:
     runs-on: ubuntu-latest
     steps:
-      - name: Add issue project board
+      - name: Add issue core project board
+        if: contains(github.event.issue.labels.*.name, 'devops') != true
         env:
           GITHUB_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
           PROJECT_ID: ${{ secrets.CORE_PROJECT_ID }}
@@ -24,3 +25,20 @@ jobs:
                 }
               }
             }' -f project=$PROJECT_ID -f issue=$ISSUE_ID --jq '.data.addProjectNextItem.projectNextItem.id'
+
+      - name: Add issue to devops project board
+        if: contains(github.event.issue.labels.*.name, 'devops')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
+          PROJECT_ID: ${{ secrets.DEVOPS_PROJECT_ID }}
+          ISSUE_ID: ${{ github.event.issue.node_id }}
+        run: |
+          gh api graphql -f query='
+            mutation($project:ID!, $issue:ID!) {
+              addProjectNextItem(input: {projectId: $project, contentId: $issue}) {
+                projectNextItem {
+                  id
+                }
+              }
+            }' -f project=$PROJECT_ID -f issue=$ISSUE_ID --jq '.data.addProjectNextItem.projectNextItem.id'
+


### PR DESCRIPTION
In some cases tickets on the vegacapsule repo will be known upfront that they are to be done by the devops team. By adding the `devops` label, on creation, these will go directly to the devops project board. All other times the issues will land on the core project board.

This is just to minimise the manual issue movement when we know up-front that the vegacapsule issue is to be worked on by devops