### PR TITLE
fix: datanode home path is now corect

### DIFF
--- a/generator/datanode/generator.go
+++ b/generator/datanode/generator.go
@@ -116,7 +116,7 @@ func (dng ConfigGenerator) OverwriteConfig(index int, configTemplate *template.T
 }
 
 func (dng ConfigGenerator) nodeDir(i int) string {
-	nodeDirName := fmt.Sprintf("%s%d", dng.conf.NodeDirPrefix, i)
+	nodeDirName := fmt.Sprintf("%s%d", *dng.conf.NodeDirPrefix, i)
 	return filepath.Join(dng.homeDir, nodeDirName)
 }
 


### PR DESCRIPTION
Previously getting paths like this 
`/Users/wwestgarth/work/tests/testnet/data/%!s(*string=0xc000501c30)5/config/data-node/config.toml`