### PR TITLE
fix: pass --home to vega bridge command during multisig init

### DIFF
--- a/cmd/ethereum.go
+++ b/cmd/ethereum.go
@@ -8,6 +8,7 @@ import (
 	"code.vegaprotocol.io/vegacapsule/ethereum"
 	"code.vegaprotocol.io/vegacapsule/state"
 	"code.vegaprotocol.io/vegacapsule/types"
+	"code.vegaprotocol.io/vegacapsule/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -95,7 +96,14 @@ var ethereumMultisigSetupCmd = &cobra.Command{
 		}
 
 		ctx := context.Background()
-		client, err := ethereum.NewEthereumClient(ctx, *netState.Config.VegaBinary, ethereumChainID, ethereumAddress, *smartcontracts)
+		client, err := ethereum.NewEthereumClient(ctx, ethereum.EthereumClientParameters{
+			VegaBinary: *netState.Config.VegaBinary,
+			VegaHome:   utils.VegaNodeHomePath(homePath, 0),
+
+			ChainID:            ethereumChainID,
+			EthereumAddress:    ethereumAddress,
+			SmartcontractsInfo: *smartcontracts,
+		})
 		if err != nil {
 			return fmt.Errorf("failed to create ethereum client: %w", err)
 		}

--- a/ethereum/commands.go
+++ b/ethereum/commands.go
@@ -7,12 +7,13 @@ import (
 	"code.vegaprotocol.io/vegacapsule/utils"
 )
 
-func setThresholdSignature(vegaBinary string, newThreshold int, nonce uint64, submitter string, signers []string) (string, error) {
+func setThresholdSignature(vegaBinary string, vegaHome string, newThreshold int, nonce uint64, submitter string, signers []string) (string, error) {
 	result := "0x"
 
 	for _, privKey := range signers {
 		signature, err := callVegaBridgeERC20(vegaBinary, []string{
 			"set_threshold",
+			"--home", vegaHome,
 			"--new-threshold", fmt.Sprintf("%d", newThreshold),
 			"--submitter", submitter,
 			"--nonce", fmt.Sprintf("%d", nonce),
@@ -32,12 +33,13 @@ func setThresholdSignature(vegaBinary string, newThreshold int, nonce uint64, su
 	return result, nil
 }
 
-func addSignerSignature(vegaBinary string, newSigner string, nonce uint64, submitter string, signers []string) (string, error) {
+func addSignerSignature(vegaBinary string, vegaHome string, newSigner string, nonce uint64, submitter string, signers []string) (string, error) {
 	result := "0x"
 
 	for _, privKey := range signers {
 		signature, err := callVegaBridgeERC20(vegaBinary, []string{
 			"add_signer",
+			"--home", vegaHome,
 			"--new-signer", newSigner,
 			"--submitter", submitter,
 			"--nonce", fmt.Sprintf("%d", nonce),
@@ -57,12 +59,13 @@ func addSignerSignature(vegaBinary string, newSigner string, nonce uint64, submi
 	return result, nil
 }
 
-func removeSignerSignature(vegaBinary string, oldSigner string, nonce uint64, submitter string, signers []string) (string, error) {
+func removeSignerSignature(vegaBinary string, vegaHome string, oldSigner string, nonce uint64, submitter string, signers []string) (string, error) {
 	result := "0x"
 
 	for _, privKey := range signers {
 		signature, err := callVegaBridgeERC20(vegaBinary, []string{
 			"remove_signer",
+			"--home", vegaHome,
 			"--old-signer", oldSigner,
 			"--submitter", submitter,
 			"--nonce", fmt.Sprintf("%d", nonce),

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -48,6 +48,10 @@ func BinaryAbsPath(p string) (string, error) {
 	return aPath, nil
 }
 
+func VegaNodeHomePath(networkHomePath string, nodeIdx int) string {
+	return filepath.Join(networkHomePath, "vega", fmt.Sprintf("node%d", nodeIdx))
+}
+
 func StrPoint(s string) *string {
 	return &s
 }


### PR DESCRIPTION
part of https://github.com/vegaprotocol/vegacapsule/issues/68 


We have to pass the `--home` flag to the `vega bridge erc20 ...` command to avoid the following error when network is initialized within the custom path:

```
Error: failed to set multisig threshold to 1: failed computing signature: failed to compute set_threshold signature for validator: adef89153e4bd6b43876045efdd6818cec359340683edaec5e8588e635e8428b: failed to execute binary /jenkins/workspace/system-tests/system-tests-capsule-experiment/tests/vega 
[bridge erc20 set_threshold --new-threshold 1 --submitter 0xb89A165EA8b619c14312dB316BaAa80D2a98B493 --nonce 25 --private-key adef89153e4bd6b43876045efdd6818cec359340683edaec5e8588e635e8428b] with error: node has not been initialised, please run `/jenkins/workspace/system-tests/system-tests-capsule-experiment/tests/vega init`
: exit status 255
```

Failed pipeline: https://jenkins.ops.vega.xyz/job/system-tests/job/system-tests-capsule-experiment/1/console
Correct pipeline: https://jenkins.ops.vega.xyz/job/system-tests/job/system-tests-capsule-experiment/3/console