### PR TITLE
feat: add --nodes-only flag to network stop

### DIFF
--- a/cmd/network_stop.go
+++ b/cmd/network_stop.go
@@ -10,6 +10,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	stopNodesOnly bool
+)
+
 var netStopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stop existing network",
@@ -31,6 +35,14 @@ var netStopCmd = &cobra.Command{
 	},
 }
 
+func init() {
+	netStopCmd.PersistentFlags().BoolVar(&stopNodesOnly,
+		"nodes-only",
+		false,
+		"Stops all nodes running in the network.",
+	)
+}
+
 func netStop(ctx context.Context, state *state.NetworkState) error {
 	log.Println("stopping network")
 
@@ -41,7 +53,7 @@ func netStop(ctx context.Context, state *state.NetworkState) error {
 
 	nomadRunner := nomad.NewJobRunner(nomadClient)
 
-	if err := nomadRunner.StopNetwork(ctx, state.RunningJobs); err != nil {
+	if err := nomadRunner.StopNetwork(ctx, state.RunningJobs, stopNodesOnly); err != nil {
 		return fmt.Errorf("failed to stop nomad network: %w", err)
 	}
 

--- a/nomad/job_runner.go
+++ b/nomad/job_runner.go
@@ -325,13 +325,16 @@ func (r *JobRunner) StartNetwork(gCtx context.Context, conf *config.Config, gene
 	return result, nil
 }
 
-func (r *JobRunner) StopNetwork(ctx context.Context, jobs *types.NetworkJobs) error {
+func (r *JobRunner) StopNetwork(ctx context.Context, jobs *types.NetworkJobs, nodesOnly bool) error {
 	// no jobs, no network started
 	if jobs == nil {
 		return nil
 	}
 
-	allJobs := append(jobs.ExtraJobIDs.ToSlice(), jobs.WalletJobID, jobs.FaucetJobID)
+	allJobs := []string{}
+	if !nodesOnly {
+		allJobs = append(jobs.ExtraJobIDs.ToSlice(), jobs.WalletJobID, jobs.FaucetJobID)
+	}
 	allJobs = append(allJobs, jobs.NodesSetsJobIDs.ToSlice()...)
 	g, ctx := errgroup.WithContext(ctx)
 	for _, jobName := range allJobs {


### PR DESCRIPTION
After `network start` We can see all nodes are running:

<img width="500" alt="obraz" src="https://user-images.githubusercontent.com/1239637/164545641-96b0be1c-d955-4dd2-acb7-6bc87b09900b.png">


Now We can call `network stop --nodes-only`

```
➜  vegacapsule git:(patch-stop-nodes-only) ✗ ./vegacapsule network stop --nodes-only
2022/04/21 22:18:47 stopping network
2022/04/21 22:18:47 Stopped Job: testnet-nodeset-full-2 - d509f1a9-73cb-97be-84df-1286357c41a7
2022/04/21 22:18:47 Stopped Job: testnet-nodeset-validator-1 - 7f9a2429-0dfd-a8a4-dea4-9ded5d1f83cb
2022/04/21 22:18:47 Stopped Job: testnet-nodeset-validator-0 - 1350e5d1-edc6-960a-b885-07f4fb15bdfd
2022/04/21 22:18:47 stopping network success
```

And finally, We can see:

<img width="500" alt="obraz" src="https://user-images.githubusercontent.com/1239637/164545775-c05cdd4e-5ce4-419b-9fb0-93f95990daea.png">
