### PR TITLE
feat: add support for auth_soft_fail in docker jobs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -64,12 +64,13 @@ type StaticPort struct {
 	Value int `hcl:"value"`
 }
 type DockerConfig struct {
-	Name       string            `hcl:"name,label"`
-	Image      string            `hcl:"image"`
-	Command    string            `hcl:"cmd"`
-	Args       []string          `hcl:"args"`
-	Env        map[string]string `hcl:"env,optional"`
-	StaticPort *StaticPort       `hcl:"static_port,block"`
+	Name         string            `hcl:"name,label"`
+	Image        string            `hcl:"image"`
+	Command      string            `hcl:"cmd"`
+	Args         []string          `hcl:"args"`
+	Env          map[string]string `hcl:"env,optional"`
+	StaticPort   *StaticPort       `hcl:"static_port,block"`
+	AuthSoftFail bool              `hcl:"auth_soft_fail,optional"`
 }
 
 type WalletConfig struct {

--- a/nomad/job_runner.go
+++ b/nomad/job_runner.go
@@ -55,10 +55,11 @@ func (r *JobRunner) runDockerJob(ctx context.Context, conf config.DockerConfig) 
 						Name:   conf.Name,
 						Driver: "docker",
 						Config: map[string]interface{}{
-							"image":   conf.Image,
-							"command": conf.Command,
-							"args":    conf.Args,
-							"ports":   portLabels,
+							"image":          conf.Image,
+							"command":        conf.Command,
+							"args":           conf.Args,
+							"ports":          portLabels,
+							"auth_soft_fail": conf.AuthSoftFail,
 						},
 						Env: conf.Env,
 						Resources: &api.Resources{


### PR DESCRIPTION
Nomad documentation says:

```
[auth_soft_fail](https://www.nomadproject.io/docs/drivers/docker#auth_soft_fail) (bool: false) - Don't fail 
the task on an auth failure. Attempt to continue without auth. If the Nomad client configuration has an auth.helper 
stanza, the helper will be tried for all images, including public images. If you mix private and public images, you 
will need to include auth_soft_fail=true in every job using a public image.
```

https://www.nomadproject.io/docs/drivers/docker#auth_soft_fail

When the `auth_soft_fail` is false and we enforced authentication in nomad config our pipelines are failing with errors:

```
Failed to find docker auth for repo "timescale/timescaledb": docker-credential-osxkeychain 
with input "timescale/timescaledb" failed with stderr: 
```