### PR TITLE
fix: fix dereference for smart contract in state command

### DIFF
--- a/cmd/state.go
+++ b/cmd/state.go
@@ -29,7 +29,7 @@ var stateGetSmartcontractsAddressesCmd = &cobra.Command{
 			return networkNotBootstrappedErr("state get-smartcontracts-addresses")
 		}
 
-		fmt.Println(netState.Config.Network.SmartContractsAddresses)
+		fmt.Println(*netState.Config.Network.SmartContractsAddresses)
 
 		return nil
 	},


### PR DESCRIPTION
Valid pipeline is here: https://jenkins.ops.vega.xyz/job/system-tests/job/system-tests-capsule/959/console