### PR TITLE
feat: switch docker image for ganache to the public one

### DIFF
--- a/config.hcl
+++ b/config.hcl
@@ -36,7 +36,7 @@ EOT
 
   pre_start {
     docker_service "ganache-1" {
-      image = "ghcr.io/vegaprotocol/devops-infra/ganache:latest"
+      image = "vegaprotocol/ganache:v1.1.0"
       cmd = "ganache-cli"
       args = [
         "--blockTime", "1",
@@ -44,13 +44,14 @@ EOT
         "--networkId", "1441",
         "-h", "0.0.0.0",
         "-p", "8545",
-        "-m", "cherry manage trip absorb logic half number test shed logic purpose rifle",
+        "-m", "ozone access unlock valid olympic save include omit supply green clown session",
         "--db", "/app/ganache-db",
       ]
       static_port {
         value = 8545
         to = 8545
       }
+	    auth_soft_fail = true
     }
   }
   
@@ -267,52 +268,52 @@ EOT
 
   smart_contracts_addresses = <<-EOT
 {
-	"addr0": {
-		"priv": "adef89153e4bd6b43876045efdd6818cec359340683edaec5e8588e635e8428b",
-		"pub": "0xb89A165EA8b619c14312dB316BaAa80D2a98B493"
-	},
-	"MultisigControl": {
-		"Ethereum": "0xa956B5c58B4Ac8Dd1D44Ade3e8972A16e9C917E4"
-	},
-	"ERC20_Asset_Pool": {
-		"Ethereum": "0x3EA59801698c6820328597F26d29fC3EaAa17AcA"
-	},
-	"erc20_bridge_1": {
-		"Ethereum": "0x0858D9BD11A4F6Bae8b979402550CA6c6ddB8332"
-	},
-	"erc20_bridge_2": {
-		"Ethereum": "0x846087f262859fe6604e2e9f787a9F3f39296Ff8"
-	},
-	"tBTC": {
-		"Ethereum": "0xc6a6000d740707edc35f75f42447320B60450c04",
-		"Vega": "0x5cfa87844724df6069b94e4c8a6f03af21907d7bc251593d08e4251043ee9f7c"
-	},
-	"tDAI": {
-		"Ethereum": "0xE25F12E386Cd7F84c41B5210504d9743A35Badda",
-		"Vega": "0x6d9d35f657589e40ddfb448b7ad4a7463b66efb307527fedd2aa7df1bbd5ea61"
-	},
-	"tEURO": {
-		"Ethereum": "0x7c23d674fED4500103A0b7e05b4A0da17291FCE9",
-		"Vega": "0x8b52d4a3a4b0ffe733cddbc2b67be273816cfeb6ca4c8b339bac03ffba08e4e4"
-	},
-	"tUSDC": {
-		"Ethereum": "0xD76Bd796e117D54044E616ae42A3577256B601D1",
-		"Vega": "0x993ed98f4f770d91a796faab1738551193ba45c62341d20597df70fea6704ede"
-	},
-	"VEGA": {
-		"Ethereum": "0xBC944ba38753A6fCAdd634Be98379330dbaB3Eb8",
-		"Vega": "0xb4f2726571fbe8e33b442dc92ed2d7f0d810e21835b7371a7915a365f07ccd9b"
-	},
-	"VEGAv1": {
-		"Ethereum": "0xB69a81EE133d8c4dC4AeCB30af93bC8698118ccE",
-		"Vega": "0xc1607f28ec1d0a0b36842c8327101b18de2c5f172585870912f5959145a9176c"
-	},
-	"erc20_vesting": {
-		"Ethereum": "0xB9f84835F00C0E4f494C51C945863109cF80754A"
-	},
-	"staking_bridge": {
-		"Ethereum": "0xE4c9fB5955bAa8a7965D000afdCEFF25cfe0E8a3"
-	}
+  "addr0": {
+    "priv": "a37f4c2a678aefb5037bf415a826df1540b330b7e471aa54184877ba901b9ef0",
+    "pub": "0xEe7D375bcB50C26d52E1A4a472D8822A2A22d94F"
+  },
+  "MultisigControl": {
+    "Ethereum": "0xdEcdA30fd3449718304eA201A8f220eBdE25dd1E"
+  },
+  "ERC20_Asset_Pool": {
+    "Ethereum": "0xAa1eDb6C25e6B5ff2c8EdAf68757Ae557178E6eE"
+  },
+  "erc20_bridge_1": {
+    "Ethereum": "0x9708FF7510D4A7B9541e1699d15b53Ecb1AFDc54"
+  },
+  "erc20_bridge_2": {
+    "Ethereum": "0x29e1eA1cfb78f7c34802C90198Cc24aDcBBE4AD0"
+  },
+  "tBTC": {
+    "Ethereum": "0xb63D135B0a6854EEb765d69ca36210cC70BECAE0",
+    "Vega": "0x5cfa87844724df6069b94e4c8a6f03af21907d7bc251593d08e4251043ee9f7c"
+  },
+  "tDAI": {
+    "Ethereum": "0x879B84eCA313D62CE4e5ED717939B42cBa9e53cb",
+    "Vega": "0x6d9d35f657589e40ddfb448b7ad4a7463b66efb307527fedd2aa7df1bbd5ea61"
+  },
+  "tEURO": {
+    "Ethereum": "0x7ccE194dAEf2A4e5C23C78C9330D4c907eCA6980",
+    "Vega": "0x8b52d4a3a4b0ffe733cddbc2b67be273816cfeb6ca4c8b339bac03ffba08e4e4"
+  },
+  "tUSDC": {
+    "Ethereum": "0x1b8a1B6CBE5c93609b46D1829Cc7f3Cb8eeE23a0",
+    "Vega": "0x993ed98f4f770d91a796faab1738551193ba45c62341d20597df70fea6704ede"
+  },
+  "VEGA": {
+    "Ethereum": "0x67175Da1D5e966e40D11c4B2519392B2058373de",
+    "Vega": "0xb4f2726571fbe8e33b442dc92ed2d7f0d810e21835b7371a7915a365f07ccd9b"
+  },
+  "VEGAv1": {
+    "Ethereum": "0x8fa21D653C1bF17741055f00dD55663Bc52a8362",
+    "Vega": "0xc1607f28ec1d0a0b36842c8327101b18de2c5f172585870912f5959145a9176c"
+  },
+  "erc20_vesting": {
+    "Ethereum": "0xF41bD86d462D36b997C0bbb4D97a0a3382f205B7"
+  },
+  "staking_bridge": {
+    "Ethereum": "0x9135f5afd6F055e731bca2348429482eE614CFfA"
+  }
 }
 EOT
 }

--- a/config_checkpoint.hcl
+++ b/config_checkpoint.hcl
@@ -36,7 +36,7 @@ EOT
 
   pre_start {
     docker_service "ganache-1" {
-      image = "ghcr.io/vegaprotocol/devops-infra/ganache:latest"
+      image = "vegaprotocol/ganache:v1.1.0"
       cmd = "ganache-cli"
       args = [
         "--blockTime", "1",
@@ -44,10 +44,14 @@ EOT
         "--networkId", "1441",
         "-h", "0.0.0.0",
         "-p", "8545",
-        "-m", "cherry manage trip absorb logic half number test shed logic purpose rifle",
+        "-m", "ozone access unlock valid olympic save include omit supply green clown session",
         "--db", "/app/ganache-db",
       ]
-      static_port = 8545
+      static_port {
+        value = 8545
+        to = 8545
+      }
+	  auth_soft_fail = true
     }
   }
 
@@ -489,52 +493,52 @@ EOT
 
   smart_contracts_addresses = <<-EOT
 {
-	"addr0": {
-		"priv": "adef89153e4bd6b43876045efdd6818cec359340683edaec5e8588e635e8428b",
-		"pub": "0xb89A165EA8b619c14312dB316BaAa80D2a98B493"
-	},
-	"MultisigControl": {
-		"Ethereum": "0xa956B5c58B4Ac8Dd1D44Ade3e8972A16e9C917E4"
-	},
-	"ERC20_Asset_Pool": {
-		"Ethereum": "0x3EA59801698c6820328597F26d29fC3EaAa17AcA"
-	},
-	"erc20_bridge_1": {
-		"Ethereum": "0x0858D9BD11A4F6Bae8b979402550CA6c6ddB8332"
-	},
-	"erc20_bridge_2": {
-		"Ethereum": "0x846087f262859fe6604e2e9f787a9F3f39296Ff8"
-	},
-	"tBTC": {
-		"Ethereum": "0xc6a6000d740707edc35f75f42447320B60450c04",
-		"Vega": "0x5cfa87844724df6069b94e4c8a6f03af21907d7bc251593d08e4251043ee9f7c"
-	},
-	"tDAI": {
-		"Ethereum": "0xE25F12E386Cd7F84c41B5210504d9743A35Badda",
-		"Vega": "0x6d9d35f657589e40ddfb448b7ad4a7463b66efb307527fedd2aa7df1bbd5ea61"
-	},
-	"tEURO": {
-		"Ethereum": "0x7c23d674fED4500103A0b7e05b4A0da17291FCE9",
-		"Vega": "0x8b52d4a3a4b0ffe733cddbc2b67be273816cfeb6ca4c8b339bac03ffba08e4e4"
-	},
-	"tUSDC": {
-		"Ethereum": "0xD76Bd796e117D54044E616ae42A3577256B601D1",
-		"Vega": "0x993ed98f4f770d91a796faab1738551193ba45c62341d20597df70fea6704ede"
-	},
-	"VEGA": {
-		"Ethereum": "0xBC944ba38753A6fCAdd634Be98379330dbaB3Eb8",
-		"Vega": "0xb4f2726571fbe8e33b442dc92ed2d7f0d810e21835b7371a7915a365f07ccd9b"
-	},
-	"VEGAv1": {
-		"Ethereum": "0xB69a81EE133d8c4dC4AeCB30af93bC8698118ccE",
-		"Vega": "0xc1607f28ec1d0a0b36842c8327101b18de2c5f172585870912f5959145a9176c"
-	},
-	"erc20_vesting": {
-		"Ethereum": "0xB9f84835F00C0E4f494C51C945863109cF80754A"
-	},
-	"staking_bridge": {
-		"Ethereum": "0xE4c9fB5955bAa8a7965D000afdCEFF25cfe0E8a3"
-	}
+  "addr0": {
+    "priv": "a37f4c2a678aefb5037bf415a826df1540b330b7e471aa54184877ba901b9ef0",
+    "pub": "0xEe7D375bcB50C26d52E1A4a472D8822A2A22d94F"
+  },
+  "MultisigControl": {
+    "Ethereum": "0xdEcdA30fd3449718304eA201A8f220eBdE25dd1E"
+  },
+  "ERC20_Asset_Pool": {
+    "Ethereum": "0xAa1eDb6C25e6B5ff2c8EdAf68757Ae557178E6eE"
+  },
+  "erc20_bridge_1": {
+    "Ethereum": "0x9708FF7510D4A7B9541e1699d15b53Ecb1AFDc54"
+  },
+  "erc20_bridge_2": {
+    "Ethereum": "0x29e1eA1cfb78f7c34802C90198Cc24aDcBBE4AD0"
+  },
+  "tBTC": {
+    "Ethereum": "0xb63D135B0a6854EEb765d69ca36210cC70BECAE0",
+    "Vega": "0x5cfa87844724df6069b94e4c8a6f03af21907d7bc251593d08e4251043ee9f7c"
+  },
+  "tDAI": {
+    "Ethereum": "0x879B84eCA313D62CE4e5ED717939B42cBa9e53cb",
+    "Vega": "0x6d9d35f657589e40ddfb448b7ad4a7463b66efb307527fedd2aa7df1bbd5ea61"
+  },
+  "tEURO": {
+    "Ethereum": "0x7ccE194dAEf2A4e5C23C78C9330D4c907eCA6980",
+    "Vega": "0x8b52d4a3a4b0ffe733cddbc2b67be273816cfeb6ca4c8b339bac03ffba08e4e4"
+  },
+  "tUSDC": {
+    "Ethereum": "0x1b8a1B6CBE5c93609b46D1829Cc7f3Cb8eeE23a0",
+    "Vega": "0x993ed98f4f770d91a796faab1738551193ba45c62341d20597df70fea6704ede"
+  },
+  "VEGA": {
+    "Ethereum": "0x67175Da1D5e966e40D11c4B2519392B2058373de",
+    "Vega": "0xb4f2726571fbe8e33b442dc92ed2d7f0d810e21835b7371a7915a365f07ccd9b"
+  },
+  "VEGAv1": {
+    "Ethereum": "0x8fa21D653C1bF17741055f00dD55663Bc52a8362",
+    "Vega": "0xc1607f28ec1d0a0b36842c8327101b18de2c5f172585870912f5959145a9176c"
+  },
+  "erc20_vesting": {
+    "Ethereum": "0xF41bD86d462D36b997C0bbb4D97a0a3382f205B7"
+  },
+  "staking_bridge": {
+    "Ethereum": "0x9135f5afd6F055e731bca2348429482eE614CFfA"
+  }
 }
 EOT
 }

--- a/config_example.hcl
+++ b/config_example.hcl
@@ -458,52 +458,52 @@ EOT
 
   smart_contracts_addresses = <<-EOT
 {
-	"addr0": {
-		"priv": "adef89153e4bd6b43876045efdd6818cec359340683edaec5e8588e635e8428b",
-		"pub": "0xb89A165EA8b619c14312dB316BaAa80D2a98B493"
-	},
-	"MultisigControl": {
-		"Ethereum": "0xa956B5c58B4Ac8Dd1D44Ade3e8972A16e9C917E4"
-	},
-	"ERC20_Asset_Pool": {
-		"Ethereum": "0x3EA59801698c6820328597F26d29fC3EaAa17AcA"
-	},
-	"erc20_bridge_1": {
-		"Ethereum": "0x0858D9BD11A4F6Bae8b979402550CA6c6ddB8332"
-	},
-	"erc20_bridge_2": {
-		"Ethereum": "0x846087f262859fe6604e2e9f787a9F3f39296Ff8"
-	},
-	"tBTC": {
-		"Ethereum": "0xc6a6000d740707edc35f75f42447320B60450c04",
-		"Vega": "0x5cfa87844724df6069b94e4c8a6f03af21907d7bc251593d08e4251043ee9f7c"
-	},
-	"tDAI": {
-		"Ethereum": "0xE25F12E386Cd7F84c41B5210504d9743A35Badda",
-		"Vega": "0x6d9d35f657589e40ddfb448b7ad4a7463b66efb307527fedd2aa7df1bbd5ea61"
-	},
-	"tEURO": {
-		"Ethereum": "0x7c23d674fED4500103A0b7e05b4A0da17291FCE9",
-		"Vega": "0x8b52d4a3a4b0ffe733cddbc2b67be273816cfeb6ca4c8b339bac03ffba08e4e4"
-	},
-	"tUSDC": {
-		"Ethereum": "0xD76Bd796e117D54044E616ae42A3577256B601D1",
-		"Vega": "0x993ed98f4f770d91a796faab1738551193ba45c62341d20597df70fea6704ede"
-	},
-	"VEGA": {
-		"Ethereum": "0xBC944ba38753A6fCAdd634Be98379330dbaB3Eb8",
-		"Vega": "0xb4f2726571fbe8e33b442dc92ed2d7f0d810e21835b7371a7915a365f07ccd9b"
-	},
-	"VEGAv1": {
-		"Ethereum": "0xB69a81EE133d8c4dC4AeCB30af93bC8698118ccE",
-		"Vega": "0xc1607f28ec1d0a0b36842c8327101b18de2c5f172585870912f5959145a9176c"
-	},
-	"erc20_vesting": {
-		"Ethereum": "0xB9f84835F00C0E4f494C51C945863109cF80754A"
-	},
-	"staking_bridge": {
-		"Ethereum": "0xE4c9fB5955bAa8a7965D000afdCEFF25cfe0E8a3"
-	}
+  "addr0": {
+    "priv": "a37f4c2a678aefb5037bf415a826df1540b330b7e471aa54184877ba901b9ef0",
+    "pub": "0xEe7D375bcB50C26d52E1A4a472D8822A2A22d94F"
+  },
+  "MultisigControl": {
+    "Ethereum": "0xdEcdA30fd3449718304eA201A8f220eBdE25dd1E"
+  },
+  "ERC20_Asset_Pool": {
+    "Ethereum": "0xAa1eDb6C25e6B5ff2c8EdAf68757Ae557178E6eE"
+  },
+  "erc20_bridge_1": {
+    "Ethereum": "0x9708FF7510D4A7B9541e1699d15b53Ecb1AFDc54"
+  },
+  "erc20_bridge_2": {
+    "Ethereum": "0x29e1eA1cfb78f7c34802C90198Cc24aDcBBE4AD0"
+  },
+  "tBTC": {
+    "Ethereum": "0xb63D135B0a6854EEb765d69ca36210cC70BECAE0",
+    "Vega": "0x5cfa87844724df6069b94e4c8a6f03af21907d7bc251593d08e4251043ee9f7c"
+  },
+  "tDAI": {
+    "Ethereum": "0x879B84eCA313D62CE4e5ED717939B42cBa9e53cb",
+    "Vega": "0x6d9d35f657589e40ddfb448b7ad4a7463b66efb307527fedd2aa7df1bbd5ea61"
+  },
+  "tEURO": {
+    "Ethereum": "0x7ccE194dAEf2A4e5C23C78C9330D4c907eCA6980",
+    "Vega": "0x8b52d4a3a4b0ffe733cddbc2b67be273816cfeb6ca4c8b339bac03ffba08e4e4"
+  },
+  "tUSDC": {
+    "Ethereum": "0x1b8a1B6CBE5c93609b46D1829Cc7f3Cb8eeE23a0",
+    "Vega": "0x993ed98f4f770d91a796faab1738551193ba45c62341d20597df70fea6704ede"
+  },
+  "VEGA": {
+    "Ethereum": "0x67175Da1D5e966e40D11c4B2519392B2058373de",
+    "Vega": "0xb4f2726571fbe8e33b442dc92ed2d7f0d810e21835b7371a7915a365f07ccd9b"
+  },
+  "VEGAv1": {
+    "Ethereum": "0x8fa21D653C1bF17741055f00dD55663Bc52a8362",
+    "Vega": "0xc1607f28ec1d0a0b36842c8327101b18de2c5f172585870912f5959145a9176c"
+  },
+  "erc20_vesting": {
+    "Ethereum": "0xF41bD86d462D36b997C0bbb4D97a0a3382f205B7"
+  },
+  "staking_bridge": {
+    "Ethereum": "0x9135f5afd6F055e731bca2348429482eE614CFfA"
+  }
 }
 EOT
 }

--- a/config_snapshot.hcl
+++ b/config_snapshot.hcl
@@ -9,7 +9,7 @@ network "testnet" {
 
   pre_start {
     docker_service "ganache-1" {
-      image = "ghcr.io/vegaprotocol/devops-infra/ganache:latest"
+      image = "vegaprotocol/ganache:v1.1.0"
       cmd = "ganache-cli"
       args = [
         "--blockTime", "1",
@@ -17,13 +17,14 @@ network "testnet" {
         "--networkId", "1441",
         "-h", "0.0.0.0",
         "-p", "8545",
-        "-m", "cherry manage trip absorb logic half number test shed logic purpose rifle",
+        "-m", "ozone access unlock valid olympic save include omit supply green clown session",
         "--db", "/app/ganache-db",
       ]
 	  static_port {
         value = 8545
         to = 8545
       }
+	  auth_soft_fail = true
     }
   }
 
@@ -347,52 +348,52 @@ EOT
 
     smart_contracts_addresses = <<EOH
 {
-	"addr0": {
-		"priv": "adef89153e4bd6b43876045efdd6818cec359340683edaec5e8588e635e8428b",
-		"pub": "0xb89A165EA8b619c14312dB316BaAa80D2a98B493"
-	},
-	"MultisigControl": {
-		"Ethereum": "0xa956B5c58B4Ac8Dd1D44Ade3e8972A16e9C917E4"
-	},
-	"ERC20_Asset_Pool": {
-		"Ethereum": "0x3EA59801698c6820328597F26d29fC3EaAa17AcA"
-	},
-	"erc20_bridge_1": {
-		"Ethereum": "0x0858D9BD11A4F6Bae8b979402550CA6c6ddB8332"
-	},
-	"erc20_bridge_2": {
-		"Ethereum": "0x846087f262859fe6604e2e9f787a9F3f39296Ff8"
-	},
-	"tBTC": {
-		"Ethereum": "0xc6a6000d740707edc35f75f42447320B60450c04",
-		"Vega": "0x5cfa87844724df6069b94e4c8a6f03af21907d7bc251593d08e4251043ee9f7c"
-	},
-	"tDAI": {
-		"Ethereum": "0xE25F12E386Cd7F84c41B5210504d9743A35Badda",
-		"Vega": "0x6d9d35f657589e40ddfb448b7ad4a7463b66efb307527fedd2aa7df1bbd5ea61"
-	},
-	"tEURO": {
-		"Ethereum": "0x7c23d674fED4500103A0b7e05b4A0da17291FCE9",
-		"Vega": "0x8b52d4a3a4b0ffe733cddbc2b67be273816cfeb6ca4c8b339bac03ffba08e4e4"
-	},
-	"tUSDC": {
-		"Ethereum": "0xD76Bd796e117D54044E616ae42A3577256B601D1",
-		"Vega": "0x993ed98f4f770d91a796faab1738551193ba45c62341d20597df70fea6704ede"
-	},
-	"VEGA": {
-		"Ethereum": "0xBC944ba38753A6fCAdd634Be98379330dbaB3Eb8",
-		"Vega": "0xb4f2726571fbe8e33b442dc92ed2d7f0d810e21835b7371a7915a365f07ccd9b"
-	},
-	"VEGAv1": {
-		"Ethereum": "0xB69a81EE133d8c4dC4AeCB30af93bC8698118ccE",
-		"Vega": "0xc1607f28ec1d0a0b36842c8327101b18de2c5f172585870912f5959145a9176c"
-	},
-	"erc20_vesting": {
-		"Ethereum": "0xB9f84835F00C0E4f494C51C945863109cF80754A"
-	},
-	"staking_bridge": {
-		"Ethereum": "0xE4c9fB5955bAa8a7965D000afdCEFF25cfe0E8a3"
-	}
+  "addr0": {
+    "priv": "a37f4c2a678aefb5037bf415a826df1540b330b7e471aa54184877ba901b9ef0",
+    "pub": "0xEe7D375bcB50C26d52E1A4a472D8822A2A22d94F"
+  },
+  "MultisigControl": {
+    "Ethereum": "0xdEcdA30fd3449718304eA201A8f220eBdE25dd1E"
+  },
+  "ERC20_Asset_Pool": {
+    "Ethereum": "0xAa1eDb6C25e6B5ff2c8EdAf68757Ae557178E6eE"
+  },
+  "erc20_bridge_1": {
+    "Ethereum": "0x9708FF7510D4A7B9541e1699d15b53Ecb1AFDc54"
+  },
+  "erc20_bridge_2": {
+    "Ethereum": "0x29e1eA1cfb78f7c34802C90198Cc24aDcBBE4AD0"
+  },
+  "tBTC": {
+    "Ethereum": "0xb63D135B0a6854EEb765d69ca36210cC70BECAE0",
+    "Vega": "0x5cfa87844724df6069b94e4c8a6f03af21907d7bc251593d08e4251043ee9f7c"
+  },
+  "tDAI": {
+    "Ethereum": "0x879B84eCA313D62CE4e5ED717939B42cBa9e53cb",
+    "Vega": "0x6d9d35f657589e40ddfb448b7ad4a7463b66efb307527fedd2aa7df1bbd5ea61"
+  },
+  "tEURO": {
+    "Ethereum": "0x7ccE194dAEf2A4e5C23C78C9330D4c907eCA6980",
+    "Vega": "0x8b52d4a3a4b0ffe733cddbc2b67be273816cfeb6ca4c8b339bac03ffba08e4e4"
+  },
+  "tUSDC": {
+    "Ethereum": "0x1b8a1B6CBE5c93609b46D1829Cc7f3Cb8eeE23a0",
+    "Vega": "0x993ed98f4f770d91a796faab1738551193ba45c62341d20597df70fea6704ede"
+  },
+  "VEGA": {
+    "Ethereum": "0x67175Da1D5e966e40D11c4B2519392B2058373de",
+    "Vega": "0xb4f2726571fbe8e33b442dc92ed2d7f0d810e21835b7371a7915a365f07ccd9b"
+  },
+  "VEGAv1": {
+    "Ethereum": "0x8fa21D653C1bF17741055f00dD55663Bc52a8362",
+    "Vega": "0xc1607f28ec1d0a0b36842c8327101b18de2c5f172585870912f5959145a9176c"
+  },
+  "erc20_vesting": {
+    "Ethereum": "0xF41bD86d462D36b997C0bbb4D97a0a3382f205B7"
+  },
+  "staking_bridge": {
+    "Ethereum": "0x9135f5afd6F055e731bca2348429482eE614CFfA"
+  }
 }
 EOH
 }

--- a/readme.md
+++ b/readme.md
@@ -7,13 +7,9 @@
 ```bash
 docker version
 ```
-2. Run `docker login` to authenticate with private package repository on Github. Github token should be used.
+2. If you use a private docker image, run `docker login` to authenticate with private package repository (eg. Github).
 ```bash
 cat PATH_TO_YOUR_TOKEN | docker login https://ghcr.io -u "YOUR_USER_NAME" --password-stdin
-```
-3. Test that docker login worked by running
-```bash
-docker pull ghcr.io/vegaprotocol/devops-infra/ganache:latest
 ```
 
 ### Start
@@ -32,17 +28,14 @@ go install
 vegacapsule nomad
 ```
 
-4. A) **For M1 users only**!
-> Please locate `docker_service "ganache-1"` block in `config.hcl` file and replace image parameter from `ghcr.io/vegaprotocol/devops-infra/ganache:latest` to `ghcr.io/vegaprotocol/devops-infra/ganache:arm64-latest`
-
-
-4. B) In another Terminal window run bootstrap command to generate and start new network
+4. In another Terminal window run bootstrap command to generate and start new network
 ```bash
 vegacapsule network bootstrap --config-path=config.hcl
 ```
 5. Check Nomad console by opening http://localhost:4646/
 
 ## Restoring network from checkpoint
+
 ### Bootstrapping a new network
 
 1. First generate the network


### PR DESCRIPTION
## Why

There are two main reasons:

- Use open-sourced images for ganache
- Use the same image for `arm64` and `amd64`

## Details:

Ganache image is located in the [vegaprotocol/docker repository](https://github.com/vegaprotocol/docker)

You can find more information about ganache image in the [vegaprotocol/ganache docker hub](https://hub.docker.com/r/vegaprotocol/ganache)

<img width="600" alt="image" src="https://user-images.githubusercontent.com/1239637/166147276-3ad42c4a-e823-40a1-bc45-4912937ebcd6.png">


## Local testing:

I have tested and I am able to start a network with a new image:

```
➜  vegacapsule git:(main) ✗ ./vegacapsule network bootstrap --config-path ./config.hcl --force
2022/05/01 14:57:17 generating network
2022/05/01 14:57:17 Initiating faucet with: /Users/daniel/go/bin/vega [faucet init --home /Users/daniel/.vegacapsule/testnet/faucet --passphrase-file /Users/daniel/.vegacapsule/testnet/faucet/faucet-wallet-pass.txt --output json]
2022/05/01 14:57:18 Initiating Tendermint node "validator" with: /Users/daniel/go/bin/vega [tm init validator --home /Users/daniel/.vegacapsule/testnet/tendermint/node0]
2022/05/01 14:57:18 I[2022-05-01|14:57:18.254] Generated private validator                  module=main keyFile=/Users/daniel/.vegacapsule/testnet/tendermint/node0/config/priv_validator_key.json stateFile=/Users/daniel/.vegacapsule/testnet/tendermint/node0/data/priv_validator_state.json
I[2022-05-01|14:57:18.255] Generated node key                           module=main path=/Users/daniel/.vegacapsule/testnet/tendermint/node0/config/node_key.json
I[2022-05-01|14:57:18.255] Generated genesis file                       module=main path=/Users/daniel/.vegacapsule/testnet/tendermint/node0/config/genesis.json

2022/05/01 14:57:18 Initiating node "validator" with: [init --home /Users/daniel/.vegacapsule/testnet/vega/node0 --nodewallet-passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node0/node-vega-wallet-pass.txt --output json validator]
2022/05/01 14:57:18 Creating vega wallet with: [wallet --home /Users/daniel/.vegacapsule/testnet/vega/node0 create --output json --passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node0/vega-wallet-pass.txt --wallet created-wallet]
2022/05/01 14:57:18 node wallet create out: &vega.createWalletOutput{Wallet:struct { Name string "json:\"name\""; FilePath string "json:\"filePath\""; RecoveryPhrase string "json:\"recoveryPhrase\"" }{Name:"created-wallet", FilePath:"/Users/daniel/.vegacapsule/testnet/vega/node0/data/wallets/created-wallet", RecoveryPhrase:"trust fold normal view hub gas document goddess kit barrel spike toward salt glue stomach feel trophy success more ceiling chase solar push habit"}, Key:struct { Public string "json:\"publicKey\"" }{Public:"e7012a9ed29b87dcad0ae496fccc92e15d7a1a8a149a1e8bfb51e1b3ac374e7f"}}
2022/05/01 14:57:18 Importing node vega wallet with: [nodewallet --home /Users/daniel/.vegacapsule/testnet/vega/node0 --passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node0/node-vega-wallet-pass.txt import --output json --chain vega --wallet-passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node0/vega-wallet-pass.txt --wallet-path /Users/daniel/.vegacapsule/testnet/vega/node0/data/wallets/created-wallet]
2022/05/01 14:57:18 node wallet import out: &vega.importNodeWalletOutput{RegistryFilePath:"/Users/daniel/.vegacapsule/testnet/vega/node0/config/node/wallets.encrypted", TendermintPubkey:"", WalletFilePath:"/Users/daniel/.vegacapsule/testnet/vega/node0/data/node/wallets/vega/vega.1651409838470156000"}
2022/05/01 14:57:18 Generating node "ethereum" wallet with: [nodewallet --home /Users/daniel/.vegacapsule/testnet/vega/node0 --passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node0/node-vega-wallet-pass.txt generate --output json --chain ethereum --wallet-passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node0/ethereum-vega-wallet-pass.txt]
2022/05/01 14:57:22 ethereum wallet out: &vega.generateNodeWalletOutput{Mnemonic:"", RegistryFilePath:"/Users/daniel/.vegacapsule/testnet/vega/node0/config/node/wallets.encrypted", WalletFilePath:"/Users/daniel/.vegacapsule/testnet/vega/node0/data/node/wallets/ethereum/UTC--2022-05-01T12-57-18.545431000Z--8a3dcfbd1fa895ebd16e20ae9181c5ce9a2d0451"}
2022/05/01 14:57:23 Importing tenderming wallet: [nodewallet --home /Users/daniel/.vegacapsule/testnet/vega/node0 --passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node0/node-vega-wallet-pass.txt import --output json --chain tendermint --tendermint-home /Users/daniel/.vegacapsule/testnet/tendermint/node0]
2022/05/01 14:57:23 tendermint wallet out: &vega.importNodeWalletOutput{RegistryFilePath:"/Users/daniel/.vegacapsule/testnet/vega/node0/config/node/wallets.encrypted", TendermintPubkey:"K3sxq5cZ/JbDGzTzbs0IjC2AB2xNvM9gkhXzWNMfk+U=", WalletFilePath:""}
2022/05/01 14:57:23 vega config initialized for node "validator" with id 0, paths: "/Users/daniel/.vegacapsule/testnet/vega/node0/config/node/config.toml"
2022/05/01 14:57:23 Initiating Tendermint node "validator" with: /Users/daniel/go/bin/vega [tm init validator --home /Users/daniel/.vegacapsule/testnet/tendermint/node1]
2022/05/01 14:57:23 I[2022-05-01|14:57:23.730] Generated private validator                  module=main keyFile=/Users/daniel/.vegacapsule/testnet/tendermint/node1/config/priv_validator_key.json stateFile=/Users/daniel/.vegacapsule/testnet/tendermint/node1/data/priv_validator_state.json
I[2022-05-01|14:57:23.730] Generated node key                           module=main path=/Users/daniel/.vegacapsule/testnet/tendermint/node1/config/node_key.json
I[2022-05-01|14:57:23.730] Generated genesis file                       module=main path=/Users/daniel/.vegacapsule/testnet/tendermint/node1/config/genesis.json

2022/05/01 14:57:23 Initiating node "validator" with: [init --home /Users/daniel/.vegacapsule/testnet/vega/node1 --nodewallet-passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node1/node-vega-wallet-pass.txt --output json validator]
2022/05/01 14:57:23 Creating vega wallet with: [wallet --home /Users/daniel/.vegacapsule/testnet/vega/node1 create --output json --passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node1/vega-wallet-pass.txt --wallet created-wallet]
2022/05/01 14:57:23 node wallet create out: &vega.createWalletOutput{Wallet:struct { Name string "json:\"name\""; FilePath string "json:\"filePath\""; RecoveryPhrase string "json:\"recoveryPhrase\"" }{Name:"created-wallet", FilePath:"/Users/daniel/.vegacapsule/testnet/vega/node1/data/wallets/created-wallet", RecoveryPhrase:"hurt mass warm castle shine tree before define silver gauge track crouch crash gossip move top purchase around desert real coil soft copy army"}, Key:struct { Public string "json:\"publicKey\"" }{Public:"47e894f1c6f465c90173bf0a8c5a0b6ab2ae210079581b278490f50d5712b1d4"}}
2022/05/01 14:57:23 Importing node vega wallet with: [nodewallet --home /Users/daniel/.vegacapsule/testnet/vega/node1 --passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node1/node-vega-wallet-pass.txt import --output json --chain vega --wallet-passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node1/vega-wallet-pass.txt --wallet-path /Users/daniel/.vegacapsule/testnet/vega/node1/data/wallets/created-wallet]
2022/05/01 14:57:23 node wallet import out: &vega.importNodeWalletOutput{RegistryFilePath:"/Users/daniel/.vegacapsule/testnet/vega/node1/config/node/wallets.encrypted", TendermintPubkey:"", WalletFilePath:"/Users/daniel/.vegacapsule/testnet/vega/node1/data/node/wallets/vega/vega.1651409843923146000"}
2022/05/01 14:57:23 Generating node "ethereum" wallet with: [nodewallet --home /Users/daniel/.vegacapsule/testnet/vega/node1 --passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node1/node-vega-wallet-pass.txt generate --output json --chain ethereum --wallet-passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node1/ethereum-vega-wallet-pass.txt]
2022/05/01 14:57:28 ethereum wallet out: &vega.generateNodeWalletOutput{Mnemonic:"", RegistryFilePath:"/Users/daniel/.vegacapsule/testnet/vega/node1/config/node/wallets.encrypted", WalletFilePath:"/Users/daniel/.vegacapsule/testnet/vega/node1/data/node/wallets/ethereum/UTC--2022-05-01T12-57-23.992066000Z--80fb1ab5373f25f48fa61eeb81783284c323c249"}
2022/05/01 14:57:28 Importing tenderming wallet: [nodewallet --home /Users/daniel/.vegacapsule/testnet/vega/node1 --passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node1/node-vega-wallet-pass.txt import --output json --chain tendermint --tendermint-home /Users/daniel/.vegacapsule/testnet/tendermint/node1]
2022/05/01 14:57:29 tendermint wallet out: &vega.importNodeWalletOutput{RegistryFilePath:"/Users/daniel/.vegacapsule/testnet/vega/node1/config/node/wallets.encrypted", TendermintPubkey:"ZY79DbKoaKtKPy9R/ktcePo7hoG2m7LQOraJya48CzI=", WalletFilePath:""}
2022/05/01 14:57:29 vega config initialized for node "validator" with id 1, paths: "/Users/daniel/.vegacapsule/testnet/vega/node1/config/node/config.toml"
2022/05/01 14:57:29 Initiating Tendermint node "full" with: /Users/daniel/go/bin/vega [tm init full --home /Users/daniel/.vegacapsule/testnet/tendermint/node2]
2022/05/01 14:57:29 I[2022-05-01|14:57:29.105] Generated private validator                  module=main keyFile=/Users/daniel/.vegacapsule/testnet/tendermint/node2/config/priv_validator_key.json stateFile=/Users/daniel/.vegacapsule/testnet/tendermint/node2/data/priv_validator_state.json
I[2022-05-01|14:57:29.105] Generated node key                           module=main path=/Users/daniel/.vegacapsule/testnet/tendermint/node2/config/node_key.json
I[2022-05-01|14:57:29.105] Generated genesis file                       module=main path=/Users/daniel/.vegacapsule/testnet/tendermint/node2/config/genesis.json

2022/05/01 14:57:29 Initiating node "full" with: [init --home /Users/daniel/.vegacapsule/testnet/vega/node2 --nodewallet-passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node2/node-vega-wallet-pass.txt --output json full]
2022/05/01 14:57:29 vega config initialized for node "full" with id 2, paths: "/Users/daniel/.vegacapsule/testnet/vega/node2/config/node/config.toml"
2022/05/01 14:57:29 Initiating data node with: /Users/daniel/go/bin/data-node [init -f --home /Users/daniel/.vegacapsule/testnet/data/node2]
2022/05/01 14:57:29 2022-05-01T14:57:29.395+0200        INFO    data-node/init.go:57    configuration generated successfully    {"path": "/Users/daniel/.vegacapsule/testnet/data/node2/config/data-node/config.toml"}

2022/05/01 14:57:29 Updating genesis with: /Users/daniel/go/bin/vega [genesis --home /Users/daniel/.vegacapsule/testnet/vega/node0 --passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node0/node-vega-wallet-pass.txt update --tm-home /Users/daniel/.vegacapsule/testnet/tendermint/node0 --dry-run]
2022/05/01 14:57:32 Updating genesis with: /Users/daniel/go/bin/vega [genesis --home /Users/daniel/.vegacapsule/testnet/vega/node1 --passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node1/node-vega-wallet-pass.txt update --tm-home /Users/daniel/.vegacapsule/testnet/tendermint/node1 --dry-run]
2022/05/01 14:57:35 Initiating wallet "wallet-1" with: [init --no-version-check --output json --home /Users/daniel/.vegacapsule/testnet/wallet]
2022/05/01 14:57:37 Importing network to wallet "wallet-1" with: [network import --no-version-check --output json --home /Users/daniel/.vegacapsule/testnet/wallet --from-file /Users/daniel/.vegacapsule/testnet/wallet/config.toml]
2022/05/01 14:57:37 generating network success
2022/05/01 14:57:37 starting network
2022/05/01 14:57:41 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:57:45 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:57:49 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:57:53 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:57:57 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:58:01 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:58:05 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:58:09 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:58:13 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:58:17 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:58:21 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:58:25 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:58:29 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:58:33 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:58:37 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:58:41 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:58:45 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:58:49 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:58:53 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:58:57 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:59:01 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:59:05 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:59:09 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:59:13 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:59:17 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:59:21 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:59:25 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:59:29 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:59:33 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:59:37 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:59:41 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:59:45 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:59:49 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "running", another: Deployment is running
2022/05/01 14:59:53 deployment (79b10533-6c2f-80e8-6bd0-8c2bc6bd0494) update for job: "ganache-1", status: "successful", another: Deployment completed successfully
2022/05/01 14:59:53 adding node set "testnet-nodeset-validator-0" with default Nomad job definition
2022/05/01 14:59:53 adding node set "testnet-nodeset-validator-1" with default Nomad job definition
2022/05/01 14:59:53 adding node set "testnet-nodeset-full-2" with default Nomad job definition
2022/05/01 14:59:57 deployment (e15341a7-6128-d4ea-7f84-49febfc42a0f) update for job: "testnet-faucet", status: "running", another: Deployment is running
2022/05/01 14:59:57 deployment (4c09cb95-e3ce-e693-4747-6db2d90fce5d) update for job: "testnet-wallet", status: "running", another: Deployment is running
2022/05/01 14:59:57 deployment (2b0b90a9-0da6-2fe9-eb65-24ab9ea15b1a) update for job: "testnet-nodeset-full-2", status: "running", another: Deployment is running
2022/05/01 14:59:57 deployment (fc715295-5dbe-ae8f-1d05-b9cbe9e5eee9) update for job: "testnet-nodeset-validator-0", status: "running", another: Deployment is running
2022/05/01 14:59:57 deployment (ea9e2191-c4a3-3e4f-40d1-543483d821a4) update for job: "testnet-nodeset-validator-1", status: "running", another: Deployment is running
2022/05/01 15:00:01 deployment (e15341a7-6128-d4ea-7f84-49febfc42a0f) update for job: "testnet-faucet", status: "running", another: Deployment is running
2022/05/01 15:00:01 deployment (4c09cb95-e3ce-e693-4747-6db2d90fce5d) update for job: "testnet-wallet", status: "running", another: Deployment is running
2022/05/01 15:00:01 deployment (2b0b90a9-0da6-2fe9-eb65-24ab9ea15b1a) update for job: "testnet-nodeset-full-2", status: "running", another: Deployment is running
2022/05/01 15:00:01 deployment (ea9e2191-c4a3-3e4f-40d1-543483d821a4) update for job: "testnet-nodeset-validator-1", status: "running", another: Deployment is running
2022/05/01 15:00:01 deployment (fc715295-5dbe-ae8f-1d05-b9cbe9e5eee9) update for job: "testnet-nodeset-validator-0", status: "running", another: Deployment is running
2022/05/01 15:00:05 deployment (e15341a7-6128-d4ea-7f84-49febfc42a0f) update for job: "testnet-faucet", status: "successful", another: Deployment completed successfully
2022/05/01 15:00:05 deployment (4c09cb95-e3ce-e693-4747-6db2d90fce5d) update for job: "testnet-wallet", status: "running", another: Deployment is running
2022/05/01 15:00:05 deployment (2b0b90a9-0da6-2fe9-eb65-24ab9ea15b1a) update for job: "testnet-nodeset-full-2", status: "successful", another: Deployment completed successfully
2022/05/01 15:00:05 deployment (ea9e2191-c4a3-3e4f-40d1-543483d821a4) update for job: "testnet-nodeset-validator-1", status: "successful", another: Deployment completed successfully
2022/05/01 15:00:05 deployment (fc715295-5dbe-ae8f-1d05-b9cbe9e5eee9) update for job: "testnet-nodeset-validator-0", status: "successful", another: Deployment completed successfully
2022/05/01 15:00:09 deployment (4c09cb95-e3ce-e693-4747-6db2d90fce5d) update for job: "testnet-wallet", status: "running", another: Deployment is running
2022/05/01 15:00:13 deployment (4c09cb95-e3ce-e693-4747-6db2d90fce5d) update for job: "testnet-wallet", status: "running", another: Deployment is running
2022/05/01 15:00:17 deployment (4c09cb95-e3ce-e693-4747-6db2d90fce5d) update for job: "testnet-wallet", status: "running", another: Deployment is running
2022/05/01 15:00:21 deployment (4c09cb95-e3ce-e693-4747-6db2d90fce5d) update for job: "testnet-wallet", status: "running", another: Deployment is running
2022/05/01 15:00:25 deployment (4c09cb95-e3ce-e693-4747-6db2d90fce5d) update for job: "testnet-wallet", status: "running", another: Deployment is running
2022/05/01 15:00:29 deployment (4c09cb95-e3ce-e693-4747-6db2d90fce5d) update for job: "testnet-wallet", status: "running", another: Deployment is running
2022/05/01 15:00:33 deployment (4c09cb95-e3ce-e693-4747-6db2d90fce5d) update for job: "testnet-wallet", status: "running", another: Deployment is running
2022/05/01 15:00:37 deployment (4c09cb95-e3ce-e693-4747-6db2d90fce5d) update for job: "testnet-wallet", status: "successful", another: Deployment completed successfully
2022/05/01 15:00:37 starting network success
➜  vegacapsule git:(main) ✗
```