### PR TITLE
fix: skip timeout set to true

### DIFF
--- a/net_confs/node_set_templates/default/tendermint_full.tmpl
+++ b/net_confs/node_set_templates/default/tendermint_full.tmpl
@@ -26,4 +26,4 @@ moniker = "{{.Prefix}}-{{.TendermintNodePrefix}}"
   cache-size = 20000
 
 [consensus]
-  skip-timeout-commit = false
+  skip_timeout_commit = true

--- a/net_confs/node_set_templates/default/tendermint_validators.tmpl
+++ b/net_confs/node_set_templates/default/tendermint_validators.tmpl
@@ -28,4 +28,4 @@ moniker = "{{.Prefix}}-{{.TendermintNodePrefix}}"
   cache-size = 20000
 
 [consensus]
-  skip-timeout-commit = false
+  skip_timeout_commit = true

--- a/net_confs/node_set_templates/sentry/tendermint_full.tmpl
+++ b/net_confs/node_set_templates/sentry/tendermint_full.tmpl
@@ -34,4 +34,4 @@ moniker = "{{.Prefix}}-{{.TendermintNodePrefix}}"
   cache-size = 20000
 
 [consensus]
-  skip-timeout-commit = false
+  skip_timeout_commit = true

--- a/net_confs/node_set_templates/sentry/tendermint_sentry-0.tmpl
+++ b/net_confs/node_set_templates/sentry/tendermint_sentry-0.tmpl
@@ -42,4 +42,4 @@ moniker = "{{.Prefix}}-{{.TendermintNodePrefix}}"
   cache-size = 20000
 
 [consensus]
-  skip-timeout-commit = false
+  skip_timeout_commit = true

--- a/net_confs/node_set_templates/sentry/tendermint_sentry-1.tmpl
+++ b/net_confs/node_set_templates/sentry/tendermint_sentry-1.tmpl
@@ -42,4 +42,4 @@ moniker = "{{.Prefix}}-{{.TendermintNodePrefix}}"
   cache-size = 20000
 
 [consensus]
-  skip-timeout-commit = false
+  skip_timeout_commit = true

--- a/net_confs/node_set_templates/sentry/tendermint_sentry-2.tmpl
+++ b/net_confs/node_set_templates/sentry/tendermint_sentry-2.tmpl
@@ -42,4 +42,4 @@ moniker = "{{.Prefix}}-{{.TendermintNodePrefix}}"
   cache-size = 20000
 
 [consensus]
-  skip-timeout-commit = false
+  skip_timeout_commit = true

--- a/net_confs/node_set_templates/sentry/tendermint_validators.tmpl
+++ b/net_confs/node_set_templates/sentry/tendermint_validators.tmpl
@@ -38,4 +38,4 @@ moniker = "{{.Prefix}}-{{.TendermintNodePrefix}}"
   cache-size = 20000
 
 [consensus]
-  skip-timeout-commit = false
+  skip_timeout_commit = true

--- a/net_confs/node_set_templates/sentry/vega_sentry.tmpl
+++ b/net_confs/node_set_templates/sentry/vega_sentry.tmpl
@@ -22,6 +22,11 @@
 	[Blockchain.Null]
 		Port = 31{{.NodeNumber}}1
 
+[Broker]
+  [Broker.Socket]
+    Port = 30{{.NodeNumber}}5
+    Enabled = true
+    
 [EvtForward]
 	Level = "Info"
 	RetryRate = "1s"


### PR DESCRIPTION
Prevent block timings from waiting the full 1 second if they are ready before.

Closes #194 