### PR TITLE
fix: save tendermint template after merge to given file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 ### 🐛 Fixes
 - [167](https://github.com/vegaprotocol/vegacapsule/issues/167) Fix validators filter in tendermint generator
 - [188](https://github.com/vegaprotocol/vegacapsule/issues/188) Support new changes for Ethereum RPC endpoint in Vega configuration
+- [209](https://github.com/vegaprotocol/vegacapsule/pull/209) Save tendermint template after merge to given file
 
 
 

--- a/generator/tendermint/templates.go
+++ b/generator/tendermint/templates.go
@@ -202,7 +202,7 @@ func (tg *ConfigGenerator) mergeAndSaveConfig(
 
 	// save
 	conf.SetRoot(ns.Tendermint.HomeDir)
-	if err := tmconfig.WriteConfigFile(ns.Tendermint.HomeDir, conf); err != nil {
+	if err := conf.WriteToTemplate(saveConfigPath); err != nil {
 		return fmt.Errorf("failed to save Tendermint config: %w", err)
 	}
 


### PR DESCRIPTION
# Description of the bug

A small bug was introduced sometime in the past. I found it when rebased my branch from the main. It is causing the previously generated `config.toml` for tendermint to be overridden when we are calling the template command.


The problem is caused because the variable `saveConfigPath` was unused.