### PR TITLE
feat: remove --no-version-check flag from vega wallet in the importer module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - [209](https://github.com/vegaprotocol/vegacapsule/pull/209) Save tendermint template after merge to given file
 - [236](https://github.com/vegaprotocol/vegacapsule/pull/236) Improve detection for Nomad pending jobs
 - [245](https://github.com/vegaprotocol/vegacapsule/pull/245) Disable Nomad pending allocations/tasks restarts
+- [248](https://github.com/vegaprotocol/vegacapsule/pull/248) Remove --no-version-check flag from vega wallet in the importer module
 
 
 

--- a/importer/vega.go
+++ b/importer/vega.go
@@ -31,7 +31,6 @@ func createIsolatedVegaWallet(nodeSet types.NodeSet, recoveryPhraseFilePath stri
 	args := []string{
 		"wallet", "import",
 		"--home", nodeSet.Vega.HomeDir,
-		"--no-version-check",
 		"--output", "json",
 		"--recovery-phrase-file", recoveryPhraseFilePath,
 		"--passphrase-file", nodeSet.Vega.NodeWalletInfo.VegaWalletPassFilePath,


### PR DESCRIPTION
The `--no-version-check` has been removed from vegawallet. This fix needs to be merged otherwise keys import fails.