### PR TITLE
feat: update clef addresses

### DIFF
--- a/jobs/clef.tmpl
+++ b/jobs/clef.tmpl
@@ -13,7 +13,7 @@ job "{{ .Name }}-{{ .Index }}" {
       driver = "docker"
 
       config {
-        image = "vegaprotocol/clef:v2.0.0"
+        image = "vegaprotocol/clef:v2.0.1"
         auth_soft_fail = true
         ports = ["http"]
       }

--- a/net_confs/config_clef.hcl
+++ b/net_confs/config_clef.hcl
@@ -84,7 +84,7 @@ EOT
     }
 
     clef_wallet {
-      ethereum_account_addresses = ["0x6fddbbaa5bc0d53d91d05157c05d86864993cd16","0x3168b80d6efc229a635aa0401600074bb40257c4"]
+      ethereum_account_addresses = ["0x5f3b6FaEE445C6e26C7fdc93De5ddb20E4eEB14f","0xBCe05047014B638d4A1374aF61A66fe85449C8F6"]
       clef_rpc_address = "http://localhost:855{{ .NodeNumber }}"
     }
 


### PR DESCRIPTION
Addresses collected from this build: https://github.com/vegaprotocol/docker/runs/7765645698?check_suite_focus=true



```
vegacapsule network bootstrap --force --config-path ./net_confs/config_clef.hcl

2022/08/31 15:41:16 generating network
2022/08/31 15:41:16 Initiating faucet with: /Users/daniel/go/bin/vega [faucet init --home /Users/daniel/.vegacapsule/testnet/faucet --passphrase-file /Users/daniel/.vegacapsule/testnet/faucet/faucet-wallet-pass.txt --output json]
2022/08/31 15:41:16 Initiating Tendermint node "full" with: /Users/daniel/go/bin/vega [tm init full --home /Users/daniel/.vegacapsule/testnet/tendermint/node2]
2022/08/31 15:41:16 I[2022-08-31|15:41:16.707] Generated private validator                  module=main keyFile=/Users/daniel/.vegacapsule/testnet/tendermint/node2/config/priv_validator_key.json stateFile=/Users/daniel/.vegacapsule/testnet/tendermint/node2/data/priv_validator_state.json
I[2022-08-31|15:41:16.707] Generated node key                           module=main path=/Users/daniel/.vegacapsule/testnet/tendermint/node2/config/node_key.json
I[2022-08-31|15:41:16.708] Generated genesis file                       module=main path=/Users/daniel/.vegacapsule/testnet/tendermint/node2/config/genesis.json

2022/08/31 15:41:16 Initiating node "full" with: [init --home /Users/daniel/.vegacapsule/testnet/vega/node2 --nodewallet-passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node2/node-vega-wallet-pass.txt --no-tendermint --output json full]
2022/08/31 15:41:16 vega config initialized for node "full" with id 2, paths: "/Users/daniel/.vegacapsule/testnet/vega/node2/config/node/config.toml"
2022/08/31 15:41:16 Initiating data node with: /Users/daniel/go/bin/data-node [init -f --home /Users/daniel/.vegacapsule/testnet/data/node2]
2022/08/31 15:41:17 2022-08-31T15:41:17.064-0500        INFO    root    commands/init.go:64     configuration generated successfully    {"path": "/Users/daniel/.vegacapsule/testnet/data/node2/config/data-node/config.toml"}

2022/08/31 15:41:20 Update for job: "clef-0", jobStatus: running, deploymentStatus: "running", another: Deployment is running
2022/08/31 15:41:20 Update for job: "clef-1", jobStatus: running, deploymentStatus: "running", another: Deployment is running
2022/08/31 15:41:20 Update for job: "clef-1", jobStatus: running, deploymentStatus: "successful", another: Deployment completed successfully
2022/08/31 15:41:20 Initiating Tendermint node "validator" with: /Users/daniel/go/bin/vega [tm init validator --home /Users/daniel/.vegacapsule/testnet/tendermint/node1]
2022/08/31 15:41:20 I[2022-08-31|15:41:20.691] Generated private validator                  module=main keyFile=/Users/daniel/.vegacapsule/testnet/tendermint/node1/config/priv_validator_key.json stateFile=/Users/daniel/.vegacapsule/testnet/tendermint/node1/data/priv_validator_state.json
I[2022-08-31|15:41:20.691] Generated node key                           module=main path=/Users/daniel/.vegacapsule/testnet/tendermint/node1/config/node_key.json
I[2022-08-31|15:41:20.691] Generated genesis file                       module=main path=/Users/daniel/.vegacapsule/testnet/tendermint/node1/config/genesis.json

2022/08/31 15:41:20 Initiating node "validator" with: [init --home /Users/daniel/.vegacapsule/testnet/vega/node1 --nodewallet-passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node1/node-vega-wallet-pass.txt --no-tendermint --output json validator]
2022/08/31 15:41:20 Creating vega wallet with: [wallet --home /Users/daniel/.vegacapsule/testnet/vega/node1 create --output json --passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node1/vega-wallet-pass.txt --wallet created-wallet]
2022/08/31 15:41:20 node wallet create out: &vega.createWalletOutput{Wallet:struct { Name string "json:\"name\""; FilePath string "json:\"filePath\""; RecoveryPhrase string "json:\"recoveryPhrase\"" }{Name:"created-wallet", FilePath:"/Users/daniel/.vegacapsule/testnet/vega/node1/data/wallets/created-wallet", RecoveryPhrase:"gown analyst coyote cattle major deny butter share topple supply narrow session census second web salon diagram mixture document donkey coffee left spatial foster"}, Key:struct { Public string "json:\"publicKey\"" }{Public:"cbd0ce4b96d4b0cd10f7df958ca128d8b16a4f444fb48ad01106ef24ff9ee8a8"}}
2022/08/31 15:41:20 Importing node vega wallet with: [nodewallet --home /Users/daniel/.vegacapsule/testnet/vega/node1 --passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node1/node-vega-wallet-pass.txt import --output json --chain vega --wallet-passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node1/vega-wallet-pass.txt --wallet-path /Users/daniel/.vegacapsule/testnet/vega/node1/data/wallets/created-wallet]
2022/08/31 15:41:20 node wallet import out: &vega.importNodeWalletOutput{RegistryFilePath:"/Users/daniel/.vegacapsule/testnet/vega/node1/config/node/wallets.encrypted", TendermintPubkey:"", WalletFilePath:"/Users/daniel/.vegacapsule/testnet/vega/node1/data/node/wallets/vega/vega.1661978480898853000"}
2022/08/31 15:41:20 wating for Clef "http://localhost:8551" to start
2022/08/31 15:41:20 received respose from Clef "http://localhost:8551" {"jsonrpc":"2.0","id":1,"result":["0x5f3b6faee445c6e26c7fdc93de5ddb20e4eeb14f","0xbce05047014b638d4a1374af61a66fe85449c8f6","0x6a2a6199611653c03e7de4be7e6b56f0efc17d0e","0xb7fcd494eb1949c20b7898d28f7f71e113f09362","0x5919863c8472aad910fbfc70bcbf24138f70affa","0xbb0509ae63d525061706961838ee5087575e72b8","0xbf6deb57100a9dfc8f43ffca2ce4c3428d396acb","0xaa601a084946ee0d55f2916261c62dfa9c077ba7","0x58ffa27dd18f81359136bd74b8593c45c8622d2e","0xd097ec952b170f6ec0046d768a3b02f83b1dafaf","0xbc6d1c78737f942eb5d887936b85672452355f4e","0x35d3cca80bfe1b4e8d1324ddc1868afd6f0a6ff8","0xbf72d1c210e6f14c5974cd1f91c4c7a7a7fecfdd","0xbf55b4ec97023b5edd7efa44f6e9ad5edf395201","0x502b6aaca386215a1258db23ec3e4d46b8bb57a9","0x99a83ed308084964ff0114494cfdb9986b53122a","0xc85bb84ec8643aafba1ecfba7ef7e43599e8e186","0x930b8fd68b93142203d6eac6ab5bdbf92e16d66a","0x89cf349fcb8fc104ded2491f2c071762d5786b54"]}
2022/08/31 15:41:20 Importing Ethereum Clef wallet: [nodewallet --home /Users/daniel/.vegacapsule/testnet/vega/node1 --passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node1/node-vega-wallet-pass.txt import --output json --chain ethereum --clef-account-address 0xBCe05047014B638d4A1374aF61A66fe85449C8F6 --eth.clef-address http://localhost:8551]
2022/08/31 15:41:20 ethereum wallet out: &vega.importNodeWalletOutput{RegistryFilePath:"/Users/daniel/.vegacapsule/testnet/vega/node1/config/node/wallets.encrypted", TendermintPubkey:"", WalletFilePath:""}
2022/08/31 15:41:20 Importing tenderming wallet: [nodewallet --home /Users/daniel/.vegacapsule/testnet/vega/node1 --passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node1/node-vega-wallet-pass.txt import --output json --chain tendermint --tendermint-home /Users/daniel/.vegacapsule/testnet/tendermint/node1]
2022/08/31 15:41:21 tendermint wallet out: &vega.importNodeWalletOutput{RegistryFilePath:"/Users/daniel/.vegacapsule/testnet/vega/node1/config/node/wallets.encrypted", TendermintPubkey:"l00CtGFEw1KACJY2FXLsQoqiymy/KKQ6egav7SNyZ3s=", WalletFilePath:""}
2022/08/31 15:41:21 vega config initialized for node "validator" with id 1, paths: "/Users/daniel/.vegacapsule/testnet/vega/node1/config/node/config.toml"
2022/08/31 15:41:24 Update for job: "clef-0", jobStatus: running, deploymentStatus: "running", another: Deployment is running
2022/08/31 15:41:28 Update for job: "clef-0", jobStatus: running, deploymentStatus: "running", another: Deployment is running
2022/08/31 15:41:32 Update for job: "clef-0", jobStatus: running, deploymentStatus: "successful", another: Deployment completed successfully
2022/08/31 15:41:32 Initiating Tendermint node "validator" with: /Users/daniel/go/bin/vega [tm init validator --home /Users/daniel/.vegacapsule/testnet/tendermint/node0]
2022/08/31 15:41:32 I[2022-08-31|15:41:32.781] Generated private validator                  module=main keyFile=/Users/daniel/.vegacapsule/testnet/tendermint/node0/config/priv_validator_key.json stateFile=/Users/daniel/.vegacapsule/testnet/tendermint/node0/data/priv_validator_state.json
I[2022-08-31|15:41:32.781] Generated node key                           module=main path=/Users/daniel/.vegacapsule/testnet/tendermint/node0/config/node_key.json
I[2022-08-31|15:41:32.781] Generated genesis file                       module=main path=/Users/daniel/.vegacapsule/testnet/tendermint/node0/config/genesis.json

2022/08/31 15:41:32 Initiating node "validator" with: [init --home /Users/daniel/.vegacapsule/testnet/vega/node0 --nodewallet-passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node0/node-vega-wallet-pass.txt --no-tendermint --output json validator]
2022/08/31 15:41:32 Creating vega wallet with: [wallet --home /Users/daniel/.vegacapsule/testnet/vega/node0 create --output json --passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node0/vega-wallet-pass.txt --wallet created-wallet]
2022/08/31 15:41:32 node wallet create out: &vega.createWalletOutput{Wallet:struct { Name string "json:\"name\""; FilePath string "json:\"filePath\""; RecoveryPhrase string "json:\"recoveryPhrase\"" }{Name:"created-wallet", FilePath:"/Users/daniel/.vegacapsule/testnet/vega/node0/data/wallets/created-wallet", RecoveryPhrase:"shrug moon panther bridge lawn side glass degree behave envelope degree honey myth valid explain off smile defense ugly weapon reward buddy pluck occur"}, Key:struct { Public string "json:\"publicKey\"" }{Public:"357d80e3aa4f51ab4464ae0c388526c0ee475d50dfafa45382126558c3ab61ba"}}
2022/08/31 15:41:32 Importing node vega wallet with: [nodewallet --home /Users/daniel/.vegacapsule/testnet/vega/node0 --passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node0/node-vega-wallet-pass.txt import --output json --chain vega --wallet-passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node0/vega-wallet-pass.txt --wallet-path /Users/daniel/.vegacapsule/testnet/vega/node0/data/wallets/created-wallet]
2022/08/31 15:41:32 node wallet import out: &vega.importNodeWalletOutput{RegistryFilePath:"/Users/daniel/.vegacapsule/testnet/vega/node0/config/node/wallets.encrypted", TendermintPubkey:"", WalletFilePath:"/Users/daniel/.vegacapsule/testnet/vega/node0/data/node/wallets/vega/vega.1661978492992302000"}
2022/08/31 15:41:32 wating for Clef "http://localhost:8550" to start
2022/08/31 15:41:33 received respose from Clef "http://localhost:8550" {"jsonrpc":"2.0","id":1,"result":["0x5f3b6faee445c6e26c7fdc93de5ddb20e4eeb14f","0xbce05047014b638d4a1374af61a66fe85449c8f6","0x6a2a6199611653c03e7de4be7e6b56f0efc17d0e","0xb7fcd494eb1949c20b7898d28f7f71e113f09362","0x5919863c8472aad910fbfc70bcbf24138f70affa","0xbb0509ae63d525061706961838ee5087575e72b8","0xbf6deb57100a9dfc8f43ffca2ce4c3428d396acb","0xaa601a084946ee0d55f2916261c62dfa9c077ba7","0x58ffa27dd18f81359136bd74b8593c45c8622d2e","0xd097ec952b170f6ec0046d768a3b02f83b1dafaf","0xbc6d1c78737f942eb5d887936b85672452355f4e","0x35d3cca80bfe1b4e8d1324ddc1868afd6f0a6ff8","0xbf72d1c210e6f14c5974cd1f91c4c7a7a7fecfdd","0xbf55b4ec97023b5edd7efa44f6e9ad5edf395201","0x502b6aaca386215a1258db23ec3e4d46b8bb57a9","0x99a83ed308084964ff0114494cfdb9986b53122a","0xc85bb84ec8643aafba1ecfba7ef7e43599e8e186","0x930b8fd68b93142203d6eac6ab5bdbf92e16d66a","0x89cf349fcb8fc104ded2491f2c071762d5786b54"]}
2022/08/31 15:41:33 Importing Ethereum Clef wallet: [nodewallet --home /Users/daniel/.vegacapsule/testnet/vega/node0 --passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node0/node-vega-wallet-pass.txt import --output json --chain ethereum --clef-account-address 0x5f3b6FaEE445C6e26C7fdc93De5ddb20E4eEB14f --eth.clef-address http://localhost:8550]
2022/08/31 15:41:33 ethereum wallet out: &vega.importNodeWalletOutput{RegistryFilePath:"/Users/daniel/.vegacapsule/testnet/vega/node0/config/node/wallets.encrypted", TendermintPubkey:"", WalletFilePath:""}
2022/08/31 15:41:33 Importing tenderming wallet: [nodewallet --home /Users/daniel/.vegacapsule/testnet/vega/node0 --passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node0/node-vega-wallet-pass.txt import --output json --chain tendermint --tendermint-home /Users/daniel/.vegacapsule/testnet/tendermint/node0]
2022/08/31 15:41:33 tendermint wallet out: &vega.importNodeWalletOutput{RegistryFilePath:"/Users/daniel/.vegacapsule/testnet/vega/node0/config/node/wallets.encrypted", TendermintPubkey:"gLCxnluFgD9xkvDuWsn/FWhL+wotYJ+S2ZLvmCvZpRc=", WalletFilePath:""}
2022/08/31 15:41:33 vega config initialized for node "validator" with id 0, paths: "/Users/daniel/.vegacapsule/testnet/vega/node0/config/node/config.toml"
2022/08/31 15:41:33 Updating genesis with: /Users/daniel/go/bin/vega [genesis --home /Users/daniel/.vegacapsule/testnet/vega/node1 --passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node1/node-vega-wallet-pass.txt update --tm-home /Users/daniel/.vegacapsule/testnet/tendermint/node1 --dry-run --eth.clef-address http://localhost:8551]
2022/08/31 15:41:33 Updating genesis with: /Users/daniel/go/bin/vega [genesis --home /Users/daniel/.vegacapsule/testnet/vega/node0 --passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node0/node-vega-wallet-pass.txt update --tm-home /Users/daniel/.vegacapsule/testnet/tendermint/node0 --dry-run --eth.clef-address http://localhost:8550]
2022/08/31 15:41:33 Initiating wallet "wallet-1" with: [init --output json --home /Users/daniel/.vegacapsule/testnet/wallet]
2022/08/31 15:41:34 Importing network to wallet "wallet-1" with: [network import --output json --home /Users/daniel/.vegacapsule/testnet/wallet --from-file /Users/daniel/.vegacapsule/testnet/wallet/config.toml]
2022/08/31 15:41:34 generating network success
2022/08/31 15:41:34 starting network
2022/08/31 15:41:38 Update for job: "ganache-1", jobStatus: running, deploymentStatus: "running", another: Deployment is running
2022/08/31 15:41:38 Update for job: "postgres-1", jobStatus: running, deploymentStatus: "running", another: Deployment is running
2022/08/31 15:41:42 Update for job: "ganache-1", jobStatus: running, deploymentStatus: "running", another: Deployment is running
2022/08/31 15:41:42 Update for job: "postgres-1", jobStatus: running, deploymentStatus: "running", another: Deployment is running
2022/08/31 15:41:46 Update for job: "postgres-1", jobStatus: running, deploymentStatus: "successful", another: Deployment completed successfully
2022/08/31 15:41:46 Update for job: "ganache-1", jobStatus: running, deploymentStatus: "running", another: Deployment is running
2022/08/31 15:41:50 Update for job: "ganache-1", jobStatus: running, deploymentStatus: "successful", another: Deployment completed successfully
2022/08/31 15:41:50 adding node set "testnet-nodeset-validators-0-validator" with default Nomad job definition
2022/08/31 15:41:50 adding node set "testnet-nodeset-validators-1-validator" with default Nomad job definition
2022/08/31 15:41:50 adding node set "testnet-nodeset-full-2-full" with default Nomad job definition
2022/08/31 15:41:54 Update for job: "testnet-wallet", jobStatus: running, deploymentStatus: "running", another: Deployment is running
2022/08/31 15:41:54 Update for job: "testnet-faucet", jobStatus: running, deploymentStatus: "running", another: Deployment is running
2022/08/31 15:41:54 Update for job: "testnet-nodeset-validators-0-validator", jobStatus: running, deploymentStatus: "running", another: Deployment is running
2022/08/31 15:41:54 Update for job: "testnet-nodeset-full-2-full", jobStatus: running, deploymentStatus: "running", another: Deployment is running
2022/08/31 15:41:54 Update for job: "testnet-nodeset-validators-1-validator", jobStatus: running, deploymentStatus: "running", another: Deployment is running
2022/08/31 15:41:58 Update for job: "testnet-wallet", jobStatus: running, deploymentStatus: "running", another: Deployment is running
2022/08/31 15:41:58 Update for job: "testnet-faucet", jobStatus: running, deploymentStatus: "running", another: Deployment is running
2022/08/31 15:41:58 Update for job: "testnet-nodeset-validators-0-validator", jobStatus: running, deploymentStatus: "running", another: Deployment is running
2022/08/31 15:41:58 Update for job: "testnet-nodeset-validators-1-validator", jobStatus: running, deploymentStatus: "running", another: Deployment is running
2022/08/31 15:41:58 Update for job: "testnet-nodeset-full-2-full", jobStatus: running, deploymentStatus: "running", another: Deployment is running
2022/08/31 15:42:02 Update for job: "testnet-wallet", jobStatus: running, deploymentStatus: "successful", another: Deployment completed successfully
2022/08/31 15:42:02 Update for job: "testnet-faucet", jobStatus: running, deploymentStatus: "successful", another: Deployment completed successfully
2022/08/31 15:42:02 Update for job: "testnet-nodeset-validators-0-validator", jobStatus: running, deploymentStatus: "successful", another: Deployment completed successfully
2022/08/31 15:42:02 Update for job: "testnet-nodeset-full-2-full", jobStatus: running, deploymentStatus: "successful", another: Deployment completed successfully
2022/08/31 15:42:02 Update for job: "testnet-nodeset-validators-1-validator", jobStatus: running, deploymentStatus: "successful", another: Deployment completed successfully
2022/08/31 15:42:02 starting network success
```


<img width="1163" alt="image" src="https://user-images.githubusercontent.com/1239637/187780284-ffea26cc-7268-4c78-96d6-a34fd4bcf04d.png">
