### PR TITLE
Remove clef address from config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - [236](https://github.com/vegaprotocol/vegacapsule/pull/236) Improve detection for Nomad pending jobs
 - [245](https://github.com/vegaprotocol/vegacapsule/pull/245) Disable Nomad pending allocations/tasks restarts
 - [248](https://github.com/vegaprotocol/vegacapsule/pull/248) Remove --no-version-check flag from vega wallet in the importer module
+- [273](https://github.com/vegaprotocol/vegacapsule/pull/273) Remove `clef-address` from `nodewallet` config file
 
 
 

--- a/ethereum/commands.go
+++ b/ethereum/commands.go
@@ -11,7 +11,6 @@ func getEthereumWalletArgs(signer Signer) []string {
 	if signer.ClefRPCAddress != "" {
 		return []string{
 			"--passphrase-file", signer.WalletPassFilePath,
-			"--eth.clef-address", signer.ClefRPCAddress,
 		}
 	}
 

--- a/generator/genesis/generator.go
+++ b/generator/genesis/generator.go
@@ -124,7 +124,6 @@ func (g *Generator) generate(nodeSets []types.NodeSet, genValidators []tmtypes.G
 			ns.Vega.HomeDir,
 			ns.Tendermint.HomeDir,
 			ns.Vega.NodeWalletPassFilePath,
-			ns.Vega.NodeWalletInfo.EthereumClefRPCAddress,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to update genesis for %q from %q: %w", ns.Tendermint.HomeDir, ns.Vega.HomeDir, err)
@@ -180,7 +179,7 @@ func (g *Generator) generate(nodeSets []types.NodeSet, genValidators []tmtypes.G
 
 func (g *Generator) updateGenesis(
 	vegaHomePath, tendermintHomePath,
-	nodeWalletPhraseFile, ethereumClefRPCAddress string,
+	nodeWalletPhraseFile string,
 ) (*updateGenesisOutput, error) {
 	args := []string{
 		"genesis",
@@ -189,10 +188,6 @@ func (g *Generator) updateGenesis(
 		"update",
 		"--tm-home", tendermintHomePath,
 		"--dry-run",
-	}
-
-	if ethereumClefRPCAddress != "" {
-		args = append(args, "--eth.clef-address", ethereumClefRPCAddress)
 	}
 
 	log.Printf("Updating genesis with: %s %v", g.vegaBinary, args)

--- a/generator/vega/commands.go
+++ b/generator/vega/commands.go
@@ -107,8 +107,8 @@ func (vg ConfigGenerator) importEthereumClefNodeWallet(
 		"import",
 		"--output", "json",
 		"--chain", "ethereum",
-		"--clef-account-address", clefAccountAddr,
-		"--eth.clef-address", clefRPCAddr,
+		"--ethereum-clef-account", clefAccountAddr,
+		"--ethereum-clef-address", clefRPCAddr,
 	}
 
 	log.Printf("Importing Ethereum Clef wallet: %v", args)

--- a/importer/ethereum.go
+++ b/importer/ethereum.go
@@ -16,7 +16,7 @@ func importEthereumKey(nodeSet types.NodeSet, ethereumPrivateKey string) (*ether
 	if err != nil {
 		return nil, fmt.Errorf("failed to import private ethereum key into node keystore: %w", err)
 	}
-
+	
 	log.Println("... adding ethereum wallet to the nodewallet")
 	ethImportArgs := []string{
 		"nodewallet", "import", "--force",

--- a/net_confs/node_set_templates/default/vega_validators_clef.tmpl
+++ b/net_confs/node_set_templates/default/vega_validators_clef.tmpl
@@ -24,10 +24,6 @@
 [Ethereum]
   RPCEndpoint = "{{.ETHEndpoint}}"
 
-[NodeWallet]
-	[NodeWallet.ETH]
-		ClefAddress = "http://127.0.0.1:855{{ .NodeNumber }}"
-
 [Processor]
 	[Processor.Ratelimit]
 		Requests = 10000


### PR DESCRIPTION
closes #273 

The way we provide the clef-address has changed a little in core. Relevant core changes are here: https://github.com/vegaprotocol/vega/pull/6300

Full system test run has been kicked off with this branch and the core branch, and the network infra tests seem to start just fine: https://jenkins.ops.vega.xyz/blue/organizations/jenkins/common%2Fsystem-tests/detail/system-tests/10150/pipeline
