### PR TITLE
fix: fix protocol protocol upgrade proposal command

### DIFF
--- a/.github/workflows/start-stop-network-test-configs.yml
+++ b/.github/workflows/start-stop-network-test-configs.yml
@@ -9,6 +9,10 @@ jobs:
     strategy:
       matrix:
         settings:
+          # example:
+          # - config_file: example_config.hcl
+          #   propose_upgrade: true
+
           - config_file: config.hcl
           - config_file: config_clef.hcl
           - config_file: config_external_postgres.hcl
@@ -17,7 +21,7 @@ jobs:
 
           # TODO: Needs to be fixed. Issue: https://github.com/vegaprotocol/vegacapsule/issues/291
           # - config_visor_only.hcl
-    name: restart with the ${{ matrix.config_file }} config file
+    name: ${{ matrix.settings.config_file }}
     runs-on: ubuntu-latest
     steps:
       - name: Setup Go
@@ -55,10 +59,19 @@ jobs:
           export PATH=$GOBIN:$PATH
 
           ./vegacapsule nodes ls;
-      - name: Network propose update
+      - name: Network propose upgrade
         if: ${{ matrix.settings.propose_upgrade }}
         run: |
-          echo "TBD"
+          export GOBIN=$(go env GOPATH)/bin
+          export PATH=$GOBIN:$PATH
+
+          ./vegacapsule nodes protocol-upgrade \
+            --propose \
+            --release-tag v0.58.0 \
+            --template-path "net_confs/node_set_templates/default/visor_run.tmpl" \
+            --height 5500 \
+            --force
+
       - name: Network destroy
         run: |
           export GOBIN=$(go env GOPATH)/bin

--- a/.github/workflows/start-stop-network-test-configs.yml
+++ b/.github/workflows/start-stop-network-test-configs.yml
@@ -12,10 +12,10 @@ jobs:
           - config.hcl
           - config_clef.hcl
           - config_external_postgres.hcl
+          - config_visor_mixed.hcl
 
           # TODO: Needs to be fixed. Issue: https://github.com/vegaprotocol/vegacapsule/issues/291
           # - config_visor_only.hcl
-          # - config_visor_mixed.hcl
     name: restart with the ${{ matrix.config_file }} config file
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/start-stop-network-test-configs.yml
+++ b/.github/workflows/start-stop-network-test-configs.yml
@@ -8,11 +8,12 @@ jobs:
   config:
     strategy:
       matrix:
-        config_file: 
-          - config.hcl
-          - config_clef.hcl
-          - config_external_postgres.hcl
-          - config_visor_mixed.hcl
+        settings:
+          - config_file: config.hcl
+          - config_file: config_clef.hcl
+          - config_file: config_external_postgres.hcl
+          - config_file: config_visor_mixed.hcl
+            propose_upgrade: true
 
           # TODO: Needs to be fixed. Issue: https://github.com/vegaprotocol/vegacapsule/issues/291
           # - config_visor_only.hcl
@@ -44,9 +45,23 @@ jobs:
         run: |
           export GOBIN=$(go env GOPATH)/bin
           export PATH=$GOBIN:$PATH
-          
+
           ./vegacapsule install-bins --install-path $GOBIN
-          ./vegacapsule network bootstrap --config-path ./net_confs/${{ matrix.config_file }} ;
+          ./vegacapsule network bootstrap --config-path ./net_confs/${{ matrix.settings.config_file }} ;
           sleep 5;
+      - name: List nodes
+        run: |
+          export GOBIN=$(go env GOPATH)/bin
+          export PATH=$GOBIN:$PATH
+
           ./vegacapsule nodes ls;
+      - name: Network propose update
+        if: ${{ matrix.settings.propose_upgrade }}
+        run: |
+          echo "TBD"
+      - name: Network destroy
+        run: |
+          export GOBIN=$(go env GOPATH)/bin
+          export PATH=$GOBIN:$PATH
+
           ./vegacapsule network destroy;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,3 +80,4 @@
 - [117](https://github.com/vegaprotocol/vegacapsule/pull/117) - fix nil dereference panics in config
 - [41](https://github.com/vegaprotocol/vegacapsule/issues/40) - persist the network state after it's generated in bootstrap command
 - [86](https://github.com/vegaprotocol/vegacapsule/issues/86) - allow overriding config options that default true with falue
+- [294](https://github.com/vegaprotocol/vegacapsule/issues/294) - do not prepare vegavisor upgrade for non vegavisor nodes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - [263](https://github.com/vegaprotocol/vegacapsule/issues/263) Add pre start probes for node sets
 - [288](https://github.com/vegaprotocol/vegacapsule/issues/288) Support Docker volumes mounts and add HCL configs templating
 - [290](https://github.com/vegaprotocol/vegacapsule/issues/290) Add multiple nodes at the same time with `count` flag
+- [291](https://github.com/vegaprotocol/vegacapsule/issues/291) Install vegavisor binary with install-bins command
 
 ### 🐛 Fixes
 - [167](https://github.com/vegaprotocol/vegacapsule/issues/167) Fix validators filter in tendermint generator
@@ -50,6 +51,7 @@
 - [228](https://github.com/vegaprotocol/vegacapsule/pull/228) Network can now be stopped/started after previous start failed
 - [289](https://github.com/vegaprotocol/vegacapsule/pull/289) Fix remove node with Visor
 - [283](https://github.com/vegaprotocol/vegacapsule/pull/283) Fix install-bins command with custom install path
+- [294](https://github.com/vegaprotocol/vegacapsule/issues/294) - do not prepare vegavisor upgrade for non vegavisor nodes
 
 
 
@@ -80,4 +82,3 @@
 - [117](https://github.com/vegaprotocol/vegacapsule/pull/117) - fix nil dereference panics in config
 - [41](https://github.com/vegaprotocol/vegacapsule/issues/40) - persist the network state after it's generated in bootstrap command
 - [86](https://github.com/vegaprotocol/vegacapsule/issues/86) - allow overriding config options that default true with falue
-- [294](https://github.com/vegaprotocol/vegacapsule/issues/294) - do not prepare vegavisor upgrade for non vegavisor nodes

--- a/cmd/nodes_protocol_upgrade.go
+++ b/cmd/nodes_protocol_upgrade.go
@@ -64,8 +64,6 @@ var nodesProtocolUpgradeCmd = &cobra.Command{
 		}
 
 		for _, ns := range nodeSets {
-			// upgrade cannot be prepared if is not running with vegavisor because
-			// visor is not initiated.
 			if ns.Visor == nil {
 				continue
 			}

--- a/cmd/nodes_protocol_upgrade.go
+++ b/cmd/nodes_protocol_upgrade.go
@@ -64,6 +64,12 @@ var nodesProtocolUpgradeCmd = &cobra.Command{
 		}
 
 		for _, ns := range nodeSets {
+			// upgrade cannot be prepared if is not running with vegavisor because
+			// visor is not initiated.
+			if ns.Visor == nil {
+				continue
+			}
+
 			if err := visorGen.PrepareUpgrade(ns.Index, upgradeReleaseTag, ns, visorRunTmpl, upgradeForce); err != nil {
 				return err
 			}
@@ -136,6 +142,7 @@ func init() {
 		false,
 		"Forces to run upgrade",
 	)
+
 	nodesProtocolUpgradeCmd.MarkFlagRequired("release-tag")
 	nodesProtocolUpgradeCmd.MarkFlagRequired("template-path")
 }

--- a/generator/visor/generator.go
+++ b/generator/visor/generator.go
@@ -97,6 +97,10 @@ func (g Generator) PrepareUpgrade(
 		}
 	}
 
+	if upgradeFolderExists, _ := utils.FileExists(upgradeFolderName); upgradeFolderExists {
+		return fmt.Errorf("protocol upgrade to that particular version already exist, use --force flag to override it")
+	}
+
 	log.Printf("Preparing upgrade folder %q for visor %q", upgradeFolderName, visorDir)
 
 	if err := os.Mkdir(upgradeFolderName, os.ModePerm); err != nil {

--- a/installer/installer.go
+++ b/installer/installer.go
@@ -21,13 +21,15 @@ const (
 	repository      = "vega"
 	repositoryOwner = "vegaprotocol"
 
-	vegaBinName = "vega"
+	vegaBinName  = "vega"
+	visorBinName = "visor"
 )
 
 var (
 	minSupportedVersion = semver.MustParse("0.54.0")
 	assetsToInstall     = map[string]string{
-		formatAssetName(vegaBinName): vegaBinName,
+		formatAssetName(vegaBinName):  vegaBinName,
+		formatAssetName(visorBinName): visorBinName,
 	}
 )
 

--- a/net_confs/node_set_templates/default/data_node_full_external_postgres.tmpl
+++ b/net_confs/node_set_templates/default/data_node_full_external_postgres.tmpl
@@ -3,9 +3,12 @@ GatewayEnabled = true
 [SQLStore]
   Enabled = true
   [SQLStore.ConnectionConfig]
+    Database = "vega{{.NodeNumber}}"
+    Host = "localhost"
+    Password = "vega"
     Port = 5232
     UseTransactions = true
-    Database = "vega{{.NodeNumber}}"
+    Username = "vega"
   
 
 [API]


### PR DESCRIPTION
Closes https://github.com/vegaprotocol/vegacapsule/issues/294 .
Closes https://github.com/vegaprotocol/vegacapsule/issues/291 .

# Changes

- Install vegavisor in the `install-bins` subcommand
- Now network upgrade for vegavisor is not prepared for non-visor nodes
- Added message to use the `-force` flag when the upgrade is already proposed for given version
- Improved e2e testing for hcl files