### PR TITLE
feat: disable de-history for common network configs

### DIFF
--- a/net_confs/node_set_templates/default/data_node_full.tmpl
+++ b/net_confs/node_set_templates/default/data_node_full.tmpl
@@ -43,3 +43,6 @@ GatewayEnabled = true
   UseEventFile = false
   [Broker.SocketConfig]
     Port = 30{{.NodeNumber}}5
+
+[DeHistory]
+  Enabled = false

--- a/net_confs/node_set_templates/default/data_node_full_external_postgres.tmpl
+++ b/net_confs/node_set_templates/default/data_node_full_external_postgres.tmpl
@@ -41,3 +41,6 @@ GatewayEnabled = true
   UseEventFile = false
   [Broker.SocketConfig]
     Port = 30{{.NodeNumber}}5
+
+[DeHistory]
+  Enabled = false


### PR DESCRIPTION
# Description

We have to disable the de-history by default because the data node fails after a few seconds.

![image](https://user-images.githubusercontent.com/1239637/199231438-7f7737b3-8ac8-4a2e-8cc9-f0750f5ed2c3.png)
