### PR TITLE
fix: add-issue-to-project errors

### DIFF
--- a/.github/workflows/add_issues_to_project.yml
+++ b/.github/workflows/add_issues_to_project.yml
@@ -1,37 +1,37 @@
 ---
 
-name: Add Issues To Project Board
+name: "Add Issues To Project Board"
 
 "on":
   issues:
     types: [opened]
+env:
+  GH_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
+  PROJECT_ID: ${{ secrets.CORE_PROJECT_ID }}
+  ISSUE_ID: ${{ github.event.issue.node_id }}
+  USER: ${{ github.actor }}
+  LABEL_ID: "LA_kwDOGuj2o87kW1sH"
 
 jobs:
   add_issue:
     runs-on: ubuntu-latest
     steps:
-      - name: Add Issue to New Core Project Board
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}
-          PROJECT_ID: ${{ secrets.CORE_PROJECT_ID }}
-          ISSUE_ID: ${{ github.event.issue.node_id }}
+      - name: "Add issue to project board"
         run: |
           gh api graphql -f query='
-            mutation($project:ID!, $issue:ID!) {
-              addProjectV2ItemById(input: {projectId: $project, contentId: $issue}) {
+            mutation($user:String!, $project:ID!, $issue:ID!) {
+              addProjectV2ItemById(input: {clientMutationId: $user, projectId: $project, contentId: $issue}) {
                 item {
                   id
                 }
               }
-            }' -f project=$PROJECT_ID -f issue=$ISSUE_ID --jq '.data.addProjectV2ItemById.item.id'
-  label_issues:
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-    steps:
-      - name: "Add vegacapsule label"
-        uses: andymckay/labeler@5c59dabdfd4dd5bd9c6e6d255b01b9d764af4414
-        with:
-          add-labels: "vegacapsule "
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+            }' -f project=$PROJECT_ID -f issue=$ISSUE_ID -f user=$USER
 
+      - name: "Add repo identify label"
+        run: |
+          gh api graphql -f query='
+            mutation($user:String!, $issue:ID!, $label:[ID!]!) {
+              addLabelsToLabelable(input: {clientMutationId: $user, labelableId: $issue, labelIds: $label}) {
+                clientMutationId
+              }
+            }' -f label=$LABEL_ID -f issue=$ISSUE_ID -f user=$USER

--- a/.github/workflows/project_managment.yml
+++ b/.github/workflows/project_managment.yml
@@ -228,7 +228,7 @@ jobs:
         run: |
           pr_item_id="$( gh api graphql -f query='
             mutation($user:String!, $project:ID!, $pr:ID!) {
-              addProjectV2ItemById(input: {clientMutationId: $user, projectId: $project, contentId: $issue}) {
+              addProjectV2ItemById(input: {clientMutationId: $user, projectId: $project, contentId: $pr}) {
                 item {
                   id
                 }
@@ -241,7 +241,7 @@ jobs:
         run: |
           pr_item_id="$( gh api graphql -f query='
             mutation($user:String!, $project:ID!, $pr:ID!) {
-              addProjectV2ItemById(input: {clientMutationId: $user, projectId: $project, contentId: $issue}) {
+              addProjectV2ItemById(input: {clientMutationId: $user, projectId: $project, contentId: $pr}) {
                 item {
                   id
                 }

--- a/.github/workflows/project_managment.yml
+++ b/.github/workflows/project_managment.yml
@@ -5,7 +5,7 @@ name: "Project Board Automation"
 
 "on":
   pull_request_target:
-    branches: [develop, main]
+    branches: [develop, master]
     types: [synchronize, opened, reopened, labeled, unlabeled, ready_for_review, review_requested, converted_to_draft, closed]
   pull_request_review:
     types: [submitted]
@@ -24,6 +24,7 @@ env:
   MERGED_COLUMN_NAME: '"Merged"'
   DONE_COLUMN_NAME: '"Done"'
   ITERATION_FIELD_NAME: 'Sprint'   # See project settings (default is `Iteration`)
+  USER: ${{ github.actor }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -211,13 +212,13 @@ jobs:
            contains(github.event.pull_request.labels.*.name, env.EXCLUDE_LABEL) != true
         run: |
           issue_item_id="$( gh api graphql -f query='
-            mutation($project:ID!, $issue:ID!) {
-              addProjectV2ItemById(input: {projectId: $project, contentId: $issue}) {
+            mutation($user:String!, $project:ID!, $issue:ID!) {
+              addProjectV2ItemById(input: {clientMutationId: $user, projectId: $project, contentId: $issue}) {
                 item {
                   id
                 }
               }
-            }' -f project=$PROJECT_ID -f issue=$LINKED_ISSUE_ID --jq '.data.addProjectV2ItemById.item.id')"
+            }' -f project=$PROJECT_ID -f issue=$LINKED_ISSUE_ID -f user=$USER --jq '.data.addProjectV2ItemById.item.id')"
           echo 'BOARD_ITEM_ID='$issue_item_id >> $GITHUB_ENV
       - name: "Add exclusion labeled PR to the project"
         id: pr-to-project
@@ -226,26 +227,26 @@ jobs:
            contains(github.event.pull_request.labels.*.name, env.EXCLUDE_LABEL) == true
         run: |
           pr_item_id="$( gh api graphql -f query='
-            mutation($project:ID!, $pr:ID!) {
-              addProjectV2ItemById(input: {projectId: $project, contentId: $pr}) {
+            mutation($user:String!, $project:ID!, $pr:ID!) {
+              addProjectV2ItemById(input: {clientMutationId: $user, projectId: $project, contentId: $issue}) {
                 item {
                   id
                 }
               }
-            }' -f project=$PROJECT_ID -f pr=$PR_ID --jq '.data.addProjectV2ItemById.item.id')"
+            }' -f project=$PROJECT_ID -f pr=$PR_ID  -f user=$USER --jq '.data.addProjectV2ItemById.item.id')"
           echo 'BOARD_ITEM_ID='$pr_item_id >> $GITHUB_ENV
       - name: "Add BOT PR to the project"
         id: bot-pr-to-project
         if: steps.bot-pr.outcome == 'success'
         run: |
           pr_item_id="$( gh api graphql -f query='
-            mutation($project:ID!, $pr:ID!) {
-              addProjectV2ItemById(input: {projectId: $project, contentId: $pr}) {
+            mutation($user:String!, $project:ID!, $pr:ID!) {
+              addProjectV2ItemById(input: {clientMutationId: $user, projectId: $project, contentId: $issue}) {
                 item {
                   id
                 }
               }
-            }' -f project=$PROJECT_ID -f pr=$PR_ID --jq '.data.addProjectV2ItemById.item.id')"
+            }' -f project=$PROJECT_ID -f pr=$PR_ID  -f user=$USER --jq '.data.addProjectV2ItemById.item.id')"
           echo 'BOARD_ITEM_ID='$pr_item_id >> $GITHUB_ENV
       - name: "Reopen if the linked issue closed"
         id: reopen-issue


### PR DESCRIPTION
The Add Issues To Project Board github action is failing due to the old API being deprecated

gh: The `ProjectNext` API is deprecated in favour of the more capable `ProjectV2` API. Follow the ProjectV2 guide at https://github.blog/changelog/2022-06-23-the-new-github-issues-june-23rd-update/, to find a suitable replacement.
{"data":{"addProjectNextItem":null},"errors":[{"type":"NOT_FOUND","path":["addProjectNextItem"],"locations":[{"line":3,"column":5}],"message":"The `ProjectNext` API is deprecated in favour of the more capable `ProjectV2` API. Follow the ProjectV2 guide at https://github.blog/changelog/2022-06-23-the-new-github-issues-june-23rd-update/, to find a suitable replacement."}]}
Error: Process completed with exit code 1.