### PR TITLE
fix: fix protocol upgrade proposal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,8 @@
 - [136](https://github.com/vegaprotocol/vegacapsule/issues/136) New templates for a sentry node with data node setup
 
 ### 🐛 Fixes
-- [117](https://github.com/vegaprotocol/vegacapsule/pull/117) - fix nil dereference panics in config
-- [41](https://github.com/vegaprotocol/vegacapsule/issues/40) - persist the network state after it's generated in bootstrap command
-- [86](https://github.com/vegaprotocol/vegacapsule/issues/86) - allow overriding config options that default true with falue
+
+- [117](https://github.com/vegaprotocol/vegacapsule/pull/117) - Fix nil dereference panics in config
+- [41](https://github.com/vegaprotocol/vegacapsule/issues/40) - Persist the network state after it's generated in bootstrap command
+- [86](https://github.com/vegaprotocol/vegacapsule/issues/86) - Allow overriding config options that default true with falue
+- [323](https://github.com/vegaprotocol/vegacapsule/pull/323) - 

--- a/commands/vega.go
+++ b/commands/vega.go
@@ -39,6 +39,7 @@ func VegaProtocolUpgradeProposal(binary, homeDir, releaseTag, height, nodeWallet
 		"--home", homeDir,
 		"--vega-release-tag", releaseTag,
 		"--height", height,
+		"--output", "json",
 		"--passphrase-file", nodeWalletPhraseFile,
 	}
 


### PR DESCRIPTION
# Issue

The `vegacapsule nodes protocol-upgrade` command returns the following error:

```log
Error: failed to submit protocol upgrade proposal to node "testnet-nodeset-validators-0-validator": failed to execute binary /Users/daniel/go/bin/vega [protocol_upgrade_proposal --home /Users/daniel/.vegacapsule/testnet/vega/node0 --vega-release-tag v0.990.0 --height 100 --passphrase-file /Users/daniel/.vegacapsule/testnet/vega/node0/node-vega-wallet-pass.txt] with error: output "human" is not script-friendly, use "json" instead
: exit status 255`
```

You can see it here. So i decided to switch the vega command output to JSON.



```
https://jenkins.ops.vega.xyz/blue/organizations/jenkins/common%2Fsystem-tests-wrapper/detail/system-tests-wrapper/23389/pipeline/429
```


The command fails even locally:

<img width="1267" alt="image" src="https://user-images.githubusercontent.com/1239637/200828387-5a82938a-ba83-4237-8fda-3fd71c12f70d.png">

