### PR TITLE
fix: brach name on project manage action

### DIFF
--- a/.github/workflows/project_managment.yml
+++ b/.github/workflows/project_managment.yml
@@ -5,7 +5,7 @@ name: "Project Board Automation"
 
 "on":
   pull_request_target:
-    branches: [develop, master]
+    branches: [main]
     types: [synchronize, opened, reopened, labeled, unlabeled, ready_for_review, review_requested, converted_to_draft, closed]
   pull_request_review:
     types: [submitted]


### PR DESCRIPTION
Fixes the project board automation not running because it was triggered by a brach that didn’t exist in this repo 