### PR TITLE
Add password file configuration for api tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - [337](https://github.com/vegaprotocol/vegacapsule/issues/337) Allow > 9 and < 100 nodes to be created.
 - [348](https://github.com/vegaprotocol/vegacapsule/issues/348) Do not parse wallet initialisation output anymore
 - [352](https://github.com/vegaprotocol/vegacapsule/issues/352) Add unique swarm key to all data nodes.
+- [356](https://github.com/vegaprotocol/vegacapsule/issues/356) Adding support for api tokens in the wallet.
 
 ### 🐛 Fixes
 - [167](https://github.com/vegaprotocol/vegacapsule/issues/167) Fix validators filter in tendermint generator

--- a/config/config.go
+++ b/config/config.go
@@ -173,8 +173,12 @@ func (c *Config) Validate(configDir string) error {
 		return fmt.Errorf("failed to validate node configs: %w", err)
 	}
 
-	if err := c.loadAndValidatSetSmartContractsAddresses(); err != nil {
-		return fmt.Errorf("invalid configuration for smart contrtacts addresses: %w", err)
+	if err := c.loadAndValidateSetSmartContractsAddresses(); err != nil {
+		return fmt.Errorf("invalid configuration for smart contracts addresses: %w", err)
+	}
+
+	if err := c.validateWalletConfig(); err != nil {
+		return fmt.Errorf("invalid configuration for wallet: %w", err)
 	}
 
 	return nil
@@ -222,6 +226,22 @@ func (c *Config) loadAndValidateNodeSets() error {
 
 	return nil
 }
+func (c *Config) validateWalletConfig() error {
+	wc := c.Network.Wallet
+
+	if wc.TokenPassphraseFile != nil {
+		tpf, err := utils.AbsPathWithPrefix(c.configDir, *wc.TokenPassphraseFile)
+		if err != nil {
+			return fmt.Errorf("failed to get absolute file path %q: %w", *wc.TokenPassphraseFile, err)
+		}
+
+		_, err = os.ReadFile(tpf)
+		if err != nil {
+			return fmt.Errorf("failed to read file %q: %w", tpf, err)
+		}
+	}
+	return nil
+}
 
 func (c *Config) validateClefWalletConfig(nc NodeConfig) error {
 	if nc.ClefWallet == nil {
@@ -229,7 +249,7 @@ func (c *Config) validateClefWalletConfig(nc NodeConfig) error {
 	}
 
 	if len(nc.ClefWallet.AccountAddresses) < nc.Count {
-		return fmt.Errorf("provided ethereum_account_addresses must be greated or equal than node condig count")
+		return fmt.Errorf("provided ethereum_account_addresses must be greater or equal than node config count")
 	}
 
 	return nil
@@ -388,7 +408,7 @@ func (c *Config) loadAndValidateGenesis() error {
 	return fmt.Errorf("missing genesis file template: either genesis_template or genesis_template_file must be defined")
 }
 
-func (c *Config) loadAndValidatSetSmartContractsAddresses() error {
+func (c *Config) loadAndValidateSetSmartContractsAddresses() error {
 	if c.Network.SmartContractsAddresses == nil {
 		if c.Network.SmartContractsAddressesFile == nil {
 			return fmt.Errorf("missing smart contracts file: either smart_contracts_addresses or smart_contracts_addresses_file must be defined")

--- a/config/config.go
+++ b/config/config.go
@@ -239,6 +239,7 @@ func (c *Config) validateWalletConfig() error {
 		if err != nil {
 			return fmt.Errorf("failed to read file %q: %w", tpf, err)
 		}
+		wc.TokenPassphraseFile = &tpf
 	}
 	return nil
 }

--- a/config/wallet_config.go
+++ b/config/wallet_config.go
@@ -29,7 +29,7 @@ type WalletConfig struct {
 	Name string `hcl:"name,label"`
 	/*
 		description: |
-					By default, the wallet config inherits the Vega binary from the main network config, but this paramater allows a user to
+					By default, the wallet config inherits the Vega binary from the main network config, but this parameter allows a user to
 					define a different Vega binary to be used in wallet.
 					This can be used if a different wallet version is required.
 					A relative or absolute path can be used. If only the binary name is defined, it automatically looks for it in $PATH.
@@ -39,6 +39,16 @@ type WalletConfig struct {
 			value: vega_binary_path = "binary_path"
 	*/
 	VegaBinary *string `hcl:"vega_binary_path,optional"`
+
+	/*
+		description: |
+					Path to the file that contains the password used to protect the api token key wallet.
+					If this value is not defined, api tokens will not be enabled.
+		example:
+			type: hcl
+			value: token_passphrase_path = "file_path"
+	*/
+	TokenPassphraseFile *string `hcl:"token_passphrase_path,optional"`
 
 	/*
 		description: |

--- a/config/wallet_config.go
+++ b/config/wallet_config.go
@@ -43,7 +43,10 @@ type WalletConfig struct {
 	/*
 		description: |
 					Path to the file that contains the password used to protect the API token to wallet.
+					API tokens are keys linked to a wallet that allow third party apps and bots to connect
+					and send transactions without the need for user interaction.
 					If this value is not defined, api tokens will not be enabled.
+					An absolute path must be used.
 		example:
 			type: hcl
 			value: token_passphrase_path = "file_path"

--- a/config/wallet_config.go
+++ b/config/wallet_config.go
@@ -42,7 +42,7 @@ type WalletConfig struct {
 
 	/*
 		description: |
-					Path to the file that contains the password used to protect the api token key wallet.
+					Path to the file that contains the password used to protect the API token to wallet.
 					If this value is not defined, api tokens will not be enabled.
 		example:
 			type: hcl

--- a/config/wallet_config.go
+++ b/config/wallet_config.go
@@ -46,7 +46,7 @@ type WalletConfig struct {
 					API tokens are keys linked to a wallet that allow third party apps and bots to connect
 					and send transactions without the need for user interaction.
 					If this value is not defined, api tokens will not be enabled.
-					An absolute path must be used.
+					A relative or absolute path can be used.
 		example:
 			type: hcl
 			value: token_passphrase_path = "file_path"

--- a/generator/initiate.go
+++ b/generator/initiate.go
@@ -19,7 +19,7 @@ func (g *Generator) initiateNodeSet(absoluteIndex, relativeIndex, groupIndex int
 
 	initTNode, err := g.tendermintGen.Initiate(absoluteIndex, n.Mode, n.Name)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initiate Tendermit node id %d for node set %s: %w", absoluteIndex, n.Name, err)
+		return nil, fmt.Errorf("failed to initiate Tendermint node id %d for node set %s: %w", absoluteIndex, n.Name, err)
 	}
 
 	initVNode, err := g.vegaGen.Initiate(
@@ -95,7 +95,7 @@ func (g *Generator) initiateNodeSets() (*nodeSets, error) {
 		for relativeIndex := 0; relativeIndex < n.Count; relativeIndex++ {
 			nc, err := n.Clone()
 			if err != nil {
-				return nil, fmt.Errorf("failed to clode node config for %q: %w", n.Name, err)
+				return nil, fmt.Errorf("failed to clone node config for %q: %w", n.Name, err)
 			}
 			absIndexC := absIndex
 			groupIndexC := groupIndex
@@ -142,7 +142,7 @@ func (g *Generator) initiateNodeSets() (*nodeSets, error) {
 func (g *Generator) initAndConfigureFaucet(conf *config.FaucetConfig) (*types.Faucet, error) {
 	initFaucet, err := g.faucetGen.InitiateAndConfigure(conf)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initate faucet: %w", err)
+		return nil, fmt.Errorf("failed to initiate faucet: %w", err)
 	}
 
 	return initFaucet, nil
@@ -156,7 +156,11 @@ func (g *Generator) initAndConfigureWallet(conf *config.WalletConfig, validators
 
 	initWallet, err := g.walletGen.InitiateWithNetworkConfig(g.conf.Network.Wallet, validatorsSet, nonValidatorSet, walletConfTemplate)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initate wallet: %w", err)
+		return nil, fmt.Errorf("failed to initiate wallet: %w", err)
+	}
+
+	if conf.TokenPassphraseFile != nil {
+		initWallet.TokenPassphrasePath = *conf.TokenPassphraseFile
 	}
 
 	return initWallet, nil

--- a/generator/wallet/commands.go
+++ b/generator/wallet/commands.go
@@ -26,6 +26,15 @@ func (cg *ConfigGenerator) initiateWallet(conf *config.WalletConfig) error {
 		return err
 	}
 
+	// If the user has configured a token pass phrase file, we should initialise the token storage
+	if conf.TokenPassphraseFile != nil && len(*conf.TokenPassphraseFile) > 0 {
+		args = []string{config.WalletSubCmd, "api-token", "init", "--home", cg.homeDir, "--passphrase-file", *conf.TokenPassphraseFile}
+		log.Printf("Initiating api-token wallet %q with: %v", conf.Name, args)
+		if _, err := utils.ExecuteBinary(vegaBinary, args, nil); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/nomad/job_runner_defaults.go
+++ b/nomad/job_runner_defaults.go
@@ -181,7 +181,22 @@ func (r *JobRunner) defaultNodeSetJob(ns types.NodeSet) *api.Job {
 }
 
 func (r *JobRunner) defaultWalletJob(wallet *types.Wallet) *api.Job {
-	job := &api.Job{
+	args := []string{
+		config.WalletSubCmd,
+		"service",
+		"run",
+		"--network", wallet.Network,
+		"--automatic-consent",
+		"--no-version-check",
+		"--output", "json",
+		"--home", wallet.HomeDir,
+	}
+
+	if len(wallet.TokenPassphrasePath) > 0 {
+		args = append(args, "--load-tokens", "--tokens-passphrase-file", wallet.TokenPassphrasePath)
+	}
+
+	return &api.Job{
 		ID:          &wallet.Name,
 		Datacenters: []string{"dc1"},
 		TaskGroups: []*api.TaskGroup{
@@ -199,16 +214,7 @@ func (r *JobRunner) defaultWalletJob(wallet *types.Wallet) *api.Job {
 						Leader: true,
 						Config: map[string]interface{}{
 							"command": wallet.BinaryPath,
-							"args": []string{
-								config.WalletSubCmd,
-								"service",
-								"run",
-								"--network", wallet.Network,
-								"--automatic-consent",
-								"--no-version-check",
-								"--output", "json",
-								"--home", wallet.HomeDir,
-							},
+							"args":    args,
 						},
 						LogConfig:   defaultLogConfig,
 						Resources:   defaultResourcesConfig,
@@ -219,15 +225,6 @@ func (r *JobRunner) defaultWalletJob(wallet *types.Wallet) *api.Job {
 			},
 		},
 	}
-	if len(wallet.TokenPassphrasePath) > 0 {
-		args := job.TaskGroups[0].Tasks[0].Config["args"].([]string)
-		args = append(args, "--load-tokens")
-		args = append(args, "--tokens-passphrase-file")
-		args = append(args, wallet.TokenPassphrasePath)
-		job.TaskGroups[0].Tasks[0].Config["args"] = args
-	}
-
-	return job
 }
 
 func (r *JobRunner) defaultFaucetJob(conf *config.FaucetConfig, fc *types.Faucet) *api.Job {

--- a/nomad/job_runner_defaults.go
+++ b/nomad/job_runner_defaults.go
@@ -181,7 +181,7 @@ func (r *JobRunner) defaultNodeSetJob(ns types.NodeSet) *api.Job {
 }
 
 func (r *JobRunner) defaultWalletJob(wallet *types.Wallet) *api.Job {
-	return &api.Job{
+	job := &api.Job{
 		ID:          &wallet.Name,
 		Datacenters: []string{"dc1"},
 		TaskGroups: []*api.TaskGroup{
@@ -219,6 +219,15 @@ func (r *JobRunner) defaultWalletJob(wallet *types.Wallet) *api.Job {
 			},
 		},
 	}
+	if len(wallet.TokenPassphrasePath) > 0 {
+		args := job.TaskGroups[0].Tasks[0].Config["args"].([]string)
+		args = append(args, "--load-tokens")
+		args = append(args, "--tokens-passphrase-file")
+		args = append(args, wallet.TokenPassphrasePath)
+		job.TaskGroups[0].Tasks[0].Config["args"] = args
+	}
+
+	return job
 }
 
 func (r *JobRunner) defaultFaucetJob(conf *config.FaucetConfig, fc *types.Faucet) *api.Job {

--- a/types/types.go
+++ b/types/types.go
@@ -14,8 +14,9 @@ type GeneratedService struct {
 
 type Wallet struct {
 	GeneratedService
-	Network    string
-	BinaryPath string
+	Network             string
+	BinaryPath          string
+	TokenPassphrasePath string
 }
 
 type Faucet struct {


### PR DESCRIPTION
Added a new parameter to the wallet configuration that when supplied is used as the password for the api tokens storage in the wallet.

Closes #356 