### PR TITLE
feat: chainID is increment in preparation for checkpoint restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - [348](https://github.com/vegaprotocol/vegacapsule/issues/348) Do not parse wallet initialisation output anymore
 - [352](https://github.com/vegaprotocol/vegacapsule/issues/352) Add unique swarm key to all data nodes.
 - [356](https://github.com/vegaprotocol/vegacapsule/issues/356) Adding support for api tokens in the wallet.
+- [358](https://github.com/vegaprotocol/vegacapsule/issues/358) The networks `chainID` is now updated when using `vegacapsule nodes restore-checkpoint` ready for a new network
 
 ### 🐛 Fixes
 - [167](https://github.com/vegaprotocol/vegacapsule/issues/167) Fix validators filter in tendermint generator

--- a/cmd/network_bootstrap.go
+++ b/cmd/network_bootstrap.go
@@ -17,7 +17,6 @@ var netBootstrapCmd = &cobra.Command{
 	Use:   "bootstrap",
 	Short: "Bootstrap generates and starts new network",
 	RunE: func(cmd *cobra.Command, args []string) error {
-
 		conf, err := config.ParseConfigFile(configFilePath, homePath, types.DefaultGeneratedServices())
 		if err != nil {
 			return fmt.Errorf("failed to parse config file: %w", err)
@@ -47,7 +46,6 @@ var netBootstrapCmd = &cobra.Command{
 		}
 
 		netState.Config = conf
-
 		updatedNetState, err := netGenerate(*netState, forceGenerate)
 		if err != nil {
 			return fmt.Errorf("failed to generate network: %w", err)

--- a/cmd/network_generate.go
+++ b/cmd/network_generate.go
@@ -73,6 +73,8 @@ func netGenerate(state state.NetworkState, force bool) (*state.NetworkState, err
 
 	log.Println("generating network")
 
+	state.VegaChainID = state.Config.Network.Name + "-001"
+
 	nomadClient, err := nomad.NewClient(nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create nomad client: %w", err)
@@ -83,7 +85,7 @@ func netGenerate(state state.NetworkState, force bool) (*state.NetworkState, err
 		return nil, fmt.Errorf("failed to create job runner: %w", err)
 	}
 
-	gen, err := generator.New(state.Config, types.GeneratedServices{}, nomadRunner)
+	gen, err := generator.New(state.Config, types.GeneratedServices{}, nomadRunner, state.VegaChainID)
 	if err != nil {
 		return nil, err
 	}
@@ -103,6 +105,5 @@ func netGenerate(state state.NetworkState, force bool) (*state.NetworkState, err
 
 	state.RunningJobs = &types.NetworkJobs{}
 	state.RunningJobs.AddExtraJobIDs(generatedSvcs.PreGenerateJobsIDs())
-
 	return &state, nil
 }

--- a/cmd/nodes_add.go
+++ b/cmd/nodes_add.go
@@ -123,7 +123,7 @@ func nodesAddNode(state state.NetworkState, index int, baseOneNode string) (*typ
 		return nil, fmt.Errorf("failed to create job runner: %w", err)
 	}
 
-	gen, err := generator.New(state.Config, *state.GeneratedServices, nomadRunner)
+	gen, err := generator.New(state.Config, *state.GeneratedServices, nomadRunner, state.VegaChainID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/nodes_remove.go
+++ b/cmd/nodes_remove.go
@@ -47,7 +47,7 @@ func init() {
 }
 
 func nodesRemoveNode(state state.NetworkState, name string) (*state.NetworkState, error) {
-	gen, err := generator.New(state.Config, *state.GeneratedServices, nomad.NewVoidJobRunner())
+	gen, err := generator.New(state.Config, *state.GeneratedServices, nomad.NewVoidJobRunner(), state.VegaChainID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/nodes_restore_cp.go
+++ b/cmd/nodes_restore_cp.go
@@ -1,16 +1,81 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
 
+	vspaths "code.vegaprotocol.io/shared/paths"
 	"code.vegaprotocol.io/vegacapsule/commands"
 	"code.vegaprotocol.io/vegacapsule/state"
+	"code.vegaprotocol.io/vegacapsule/types"
+	"github.com/BurntSushi/toml"
 	"github.com/spf13/cobra"
 )
 
-var (
-	checkpointFile string
-)
+var checkpointFile string
+
+func incrementChainID(chainID string) (string, error) {
+	s := strings.Split(chainID, "-")
+	i, err := strconv.ParseInt(s[len(s)-1], 10, 64)
+	if err != nil {
+		return "", fmt.Errorf("could not increment chain-id %s: %w", chainID, err)
+	}
+	return strings.Join(s[:len(s)-1], "-") + fmt.Sprintf("-%03d", i+1), nil
+}
+
+func updateGenesisChainID(ns types.NodeSet, chainID string) error {
+	f, err := os.Open(ns.Tendermint.GenesisFilePath)
+	if err != nil {
+		return err
+	}
+
+	b, err := io.ReadAll(f)
+	f.Close()
+	if err != nil {
+		return err
+	}
+
+	var genesis map[string]interface{}
+	if err := json.Unmarshal(b, &genesis); err != nil {
+		return fmt.Errorf("failed unmarshal tendermint config: %w", err)
+	}
+
+	genesis["chain_id"] = chainID
+	b, err = json.MarshalIndent(genesis, "", "    ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(ns.Tendermint.GenesisFilePath, b, 0o644)
+}
+
+func updateDataNodeChainID(ns types.NodeSet, chainID string) error {
+	f, err := os.Open(ns.DataNode.ConfigFilePath)
+	if err != nil {
+		return err
+	}
+
+	b, err := io.ReadAll(f)
+	f.Close()
+	if err != nil {
+		return err
+	}
+
+	var cfg map[string]interface{}
+	if _, err := toml.Decode(string(b), &cfg); err != nil {
+		return fmt.Errorf("failed decode datanode config: %w", err)
+	}
+
+	cfg["ChainID"] = chainID
+	if err := vspaths.WriteStructuredFile(ns.DataNode.ConfigFilePath, cfg); err != nil {
+		return fmt.Errorf("failed to write configuration file at %s: %w", ns.DataNode.ConfigFilePath, err)
+	}
+
+	return nil
+}
 
 var nodesRestoreCheckpointCmd = &cobra.Command{
 	Use:   "restore-checkpoint",
@@ -29,6 +94,15 @@ var nodesRestoreCheckpointCmd = &cobra.Command{
 			return fmt.Errorf("parameter checkpoint-file can not be empty")
 		}
 
+		chainID, err := incrementChainID(netState.VegaChainID)
+		if err != nil {
+			return err
+		}
+
+		netState.VegaChainID = chainID
+		if err := netState.Persist(); err != nil {
+			return err
+		}
 		for _, ns := range netState.GeneratedServices.NodeSets {
 			r, err := commands.VegaRestoreCheckpoint(
 				*netState.Config.VegaBinary,
@@ -40,9 +114,18 @@ var nodesRestoreCheckpointCmd = &cobra.Command{
 				return fmt.Errorf("failed to restore node %q from checkpoint: %w", ns.Name, err)
 			}
 
+			if err := updateGenesisChainID(ns, chainID); err != nil {
+				return fmt.Errorf("unable to add new chain id to genesis file for %s: %w", ns.Name, err)
+			}
+
+			if ns.DataNode != nil {
+				if err := updateDataNodeChainID(ns, chainID); err != nil {
+					return fmt.Errorf("unable to add new chain id to datanode config for %s: %w", ns.Name, err)
+				}
+			}
+
 			fmt.Printf("applied transaction for node set %q: %s", ns.Name, r)
 		}
-
 		return nil
 	},
 }

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -50,9 +50,10 @@ type Generator struct {
 	faucetGen     *faucet.ConfigGenerator
 	visorGen      *visor.Generator
 	jobRunner     jobRunner
+	chainID       string
 }
 
-func New(conf *config.Config, genServices types.GeneratedServices, jobRunner jobRunner) (*Generator, error) {
+func New(conf *config.Config, genServices types.GeneratedServices, jobRunner jobRunner, chainID string) (*Generator, error) {
 	tendermintGen, err := tendermint.NewConfigGenerator(conf, genServices.NodeSets.ToSlice())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new tendermint config generator: %w", err)
@@ -92,6 +93,7 @@ func New(conf *config.Config, genServices types.GeneratedServices, jobRunner job
 		faucetGen:     faucetGen,
 		visorGen:      visorGen,
 		jobRunner:     jobRunner,
+		chainID:       chainID,
 	}, nil
 }
 
@@ -114,7 +116,7 @@ func (g *Generator) configureNodeSets(nss *nodeSets, fc *types.Faucet) error {
 }
 
 func (g *Generator) vegaChainID() string {
-	return g.conf.Network.Name
+	return g.chainID
 }
 
 func (g *Generator) Generate() (genSvc *types.GeneratedServices, err error) {

--- a/state/state.go
+++ b/state/state.go
@@ -16,6 +16,7 @@ type NetworkState struct {
 	Config            *config.Config
 	GeneratedServices *types.GeneratedServices
 	RunningJobs       *types.NetworkJobs
+	VegaChainID       string
 }
 
 func (ns *NetworkState) Empty() bool {
@@ -32,9 +33,8 @@ func (ns NetworkState) Persist() error {
 		return fmt.Errorf("failed to persist network state: %w", err)
 	}
 
-	if err := os.WriteFile(stateFilePath(*ns.Config.OutputDir), networkBytes, 0644); err != nil {
+	if err := os.WriteFile(stateFilePath(*ns.Config.OutputDir), networkBytes, 0o644); err != nil {
 		return fmt.Errorf("failed to persist network state: %w", err)
-
 	}
 
 	return nil


### PR DESCRIPTION
closes #358 

To unblock https://github.com/vegaprotocol/vega/issues/7000 we need the chainID to be incremented before doing a check-point restore. This now happens automatically when calling the `vegacapsule nodes restore-checkpoint` command.

Full system test run over all the checkpoint tests: https://jenkins.ops.vega.xyz/blue/organizations/jenkins/common%2Fsystem-tests/detail/system-tests/14802/pipeline