### PR TITLE
feat: add flag to save added node details in the `nodes add` subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - [356](https://github.com/vegaprotocol/vegacapsule/issues/356) Adding support for api tokens in the wallet.
 - [358](https://github.com/vegaprotocol/vegacapsule/issues/358) The networks `chainID` is now updated when using `vegacapsule nodes restore-checkpoint` ready for a new network
 - [365](https://github.com/vegaprotocol/vegacapsule/issues/365) Add ability to run arbitrary processes in the `prestart`
+- [367](https://github.com/vegaprotocol/vegacapsule/pull/367) Use proper JSON foramt to report new nodes details in the `vegacapsule nodes add` command, allow to save those details in the file
 
 ### 🐛 Fixes
 - [167](https://github.com/vegaprotocol/vegacapsule/issues/167) Fix validators filter in tendermint generator

--- a/cmd/nodes_add.go
+++ b/cmd/nodes_add.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"sync"
 
 	"code.vegaprotocol.io/vegacapsule/generator"
@@ -14,9 +15,10 @@ import (
 )
 
 var (
-	baseOneNode string
-	startNode   bool
-	count       int
+	baseOneNode    string
+	startNode      bool
+	resultsOutPath string
+	count          int
 )
 
 var nodesAddCmd = &cobra.Command{
@@ -79,13 +81,16 @@ var nodesAddCmd = &cobra.Command{
 			return fmt.Errorf("failed to persist network: %w", err)
 		}
 
-		for _, ns := range newNodeSets {
-			newNodeJson, err := json.MarshalIndent(ns, "", "\t")
-			if err != nil {
-				return fmt.Errorf("failed to marshal validators info: %w", err)
-			}
+		outputStringJSON, err := json.MarshalIndent(newNodeSets, "", "\t")
+		if err != nil {
+			return fmt.Errorf("failed to marshal validators info: %w", err)
+		}
 
-			fmt.Println(string(newNodeJson))
+		fmt.Println(string(outputStringJSON))
+		if resultsOutPath != "" {
+			if err := os.WriteFile(resultsOutPath, outputStringJSON, 0666); err != nil {
+				return fmt.Errorf("failed to save results about new nodes into the file: %w", err)
+			}
 		}
 
 		return nil
@@ -109,6 +114,12 @@ func init() {
 		"count",
 		1,
 		"Defines how many node sets should be added",
+	)
+
+	nodesAddCmd.PersistentFlags().StringVar(&resultsOutPath,
+		"out-path",
+		"",
+		"If not empty, details about added nodes are saved in the given file",
 	)
 }
 


### PR DESCRIPTION
closes https://github.com/vegaprotocol/devops-infra/issues/1632

# Description of change

I have added the `--out-path` flag, which is used to save JSON details about new(added) nodes. I cannot use the stdout because it prints logs(non-JSON) which is not easy to parse. I could strip logs, but I need files in bash as well to get some data about the new n ode.

```
➜  scripts git:(develop) ✗ vegacapsule --home-path /Users/daniel/www/vega/networkdata/testnet nodes add --base-on=testnet-nodeset-full-2-full --start=false
2023/01/20 12:02:09 Initiating Tendermint node "full" with: /Users/daniel/www/vega/networkdata/vega [tm init full --home /Users/daniel/www/vega/networkdata/testnet/tendermint/node3]
2023/01/20 12:02:09 I[2023-01-20|12:02:09.434] Generated private validator                  module=main keyFile=/Users/daniel/www/vega/networkdata/testnet/tendermint/node3/config/priv_validator_key.json stateFile=/Users/daniel/www/vega/networkdata/testnet/tendermint/node3/data/priv_validator_state.json
I[2023-01-20|12:02:09.434] Generated node key                           module=main path=/Users/daniel/www/vega/networkdata/testnet/tendermint/node3/config/node_key.json
I[2023-01-20|12:02:09.434] Generated genesis file                       module=main path=/Users/daniel/www/vega/networkdata/testnet/tendermint/node3/config/genesis.json

2023/01/20 12:02:09 Initiating node "full" with: /Users/daniel/www/vega/networkdata/vega [init --home /Users/daniel/www/vega/networkdata/testnet/vega/node3 --nodewallet-passphrase-file /Users/daniel/www/vega/networkdata/testnet/vega/node3/node-vega-wallet-pass.txt --no-tendermint --output json full]
2023/01/20 12:02:09 vega config initialized for node "full" with id 3, paths: "/Users/daniel/www/vega/networkdata/testnet/vega/node3/config/node/config.toml"
2023/01/20 12:02:09 Initiating data node with: /Users/daniel/www/vega/networkdata/vega [datanode init -f --home /Users/daniel/www/vega/networkdata/testnet/data-node/node3 testnet]
2023/01/20 12:02:09 2023-01-20T12:02:09.643+0100        INFO    root    commands/init.go:72     configuration generated successfully    {"path": "/Users/daniel/www/vega/networkdata/testnet/data-node/node3/config/data-node/config.toml"}

2023/01/20 12:02:09 Overwriting Tendermint config for nodeset testnet-nodeset-full-3-full
2023/01/20 12:02:09 Overwriting Vega config for nodeset testnet-nodeset-full-3-full
2023/01/20 12:02:09 Overwriting Data Node config for nodeset testnet-nodeset-full-3-full
2023/01/20 12:02:09 Added new node set with id "testnet-nodeset-full-3-full"
{
        "GroupName": "full",
        "Name": "testnet-nodeset-full-3-full",
        "Mode": "full",
        "Index": 3,
        "RelativeIndex": 1,
        "GroupIndex": 1,
        "Vega": {
                "Name": "vega-full-3",
                "HomeDir": "/Users/daniel/www/vega/networkdata/testnet/vega/node3",
                "ConfigFilePath": "/Users/daniel/www/vega/networkdata/testnet/vega/node3/config/node/config.toml",
                "Mode": "full",
                "NodeWalletPassFilePath": "/Users/daniel/www/vega/networkdata/testnet/vega/node3/node-vega-wallet-pass.txt",
                "BinaryPath": "/Users/daniel/www/vega/networkdata/vega"
        },
        "Tendermint": {
                "Name": "tendermint-full-3",
                "HomeDir": "/Users/daniel/www/vega/networkdata/testnet/tendermint/node3",
                "ConfigFilePath": "/Users/daniel/www/vega/networkdata/testnet/tendermint/node3/config/config.toml",
                "NodeID": "3b9bc3db27064b2819e1ff2a3e05b58d37c23d84",
                "GenesisFilePath": "/Users/daniel/www/vega/networkdata/testnet/tendermint/node3/config/genesis.json",
                "BinaryPath": "/Users/daniel/www/vega/networkdata/vega",
                "ValidatorPublicKey": ""
        },
        "DataNode": {
                "Name": "data-node-3",
                "HomeDir": "/Users/daniel/www/vega/networkdata/testnet/data-node/node3",
                "ConfigFilePath": "/Users/daniel/www/vega/networkdata/testnet/data-node/node3/config/data-node/config.toml",
                "BinaryPath": "/Users/daniel/www/vega/networkdata/vega"
        },
        "Visor": null,
        "PreGenerateJobs": null,
        "PreStartProbe": {
                "HTTP": null,
                "TCP": null,
                "Postgres": {
                        "Connection": "user=vega dbname=vega3 password=vega port=5532 sslmode=disable",
                        "Query": "select 10 + 10"
                }
        }
}
```

New flag allows me to save the following info in the given file:

```
{
        "GroupName": "full",
        "Name": "testnet-nodeset-full-3-full",
        "Mode": "full",
        "Index": 3,
        "RelativeIndex": 1,
        "GroupIndex": 1,
        "Vega": {
                "Name": "vega-full-3",
                "HomeDir": "/Users/daniel/www/vega/networkdata/testnet/vega/node3",
                "ConfigFilePath": "/Users/daniel/www/vega/networkdata/testnet/vega/node3/config/node/config.toml",
                "Mode": "full",
                "NodeWalletPassFilePath": "/Users/daniel/www/vega/networkdata/testnet/vega/node3/node-vega-wallet-pass.txt",
                "BinaryPath": "/Users/daniel/www/vega/networkdata/vega"
        },
        "Tendermint": {
                "Name": "tendermint-full-3",
                "HomeDir": "/Users/daniel/www/vega/networkdata/testnet/tendermint/node3",
                "ConfigFilePath": "/Users/daniel/www/vega/networkdata/testnet/tendermint/node3/config/config.toml",
                "NodeID": "3b9bc3db27064b2819e1ff2a3e05b58d37c23d84",
                "GenesisFilePath": "/Users/daniel/www/vega/networkdata/testnet/tendermint/node3/config/genesis.json",
                "BinaryPath": "/Users/daniel/www/vega/networkdata/vega",
                "ValidatorPublicKey": ""
        },
        "DataNode": {
                "Name": "data-node-3",
                "HomeDir": "/Users/daniel/www/vega/networkdata/testnet/data-node/node3",
                "ConfigFilePath": "/Users/daniel/www/vega/networkdata/testnet/data-node/node3/config/data-node/config.toml",
                "BinaryPath": "/Users/daniel/www/vega/networkdata/vega"
        },
        "Visor": null,
        "PreGenerateJobs": null,
        "PreStartProbe": {
                "HTTP": null,
                "TCP": null,
                "Postgres": {
                        "Connection": "user=vega dbname=vega3 password=vega port=5532 sslmode=disable",
                        "Query": "select 10 + 10"
                }
        }
}
```