### PR TITLE
feat: start node base on group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@
 - [124](https://github.com/vegaprotocol/vegacapsule/issues/124) Allow updating network configurations with templating after network is generated
 - [139](https://github.com/vegaprotocol/vegacapsule/issues/139) Allow non validator nodes to be iterated during wallet configuration
 - [136](https://github.com/vegaprotocol/vegacapsule/issues/136) New templates for a sentry node with data node setup
+- [391](https://github.com/vegaprotocol/vegacapsule/pull/391) Add support for adding new nodes from a node set instad of another running node
 
 ### 🐛 Fixes
 

--- a/cmd/nodes_add.go
+++ b/cmd/nodes_add.go
@@ -114,8 +114,6 @@ func init() {
 		"",
 		"Name of the group that the new node set should be based on",
 	)
-	nodesAddCmd.MarkFlagRequired("base-on")
-
 	nodesAddCmd.PersistentFlags().IntVar(&count,
 		"count",
 		1,
@@ -173,11 +171,10 @@ func nodesAddNode(state state.NetworkState, index int, baseOnNode, baseOnGroup s
 		groupIndex = nodeSet.GroupIndex
 	} else {
 		for groupIdx, group := range state.Config.Network.Nodes {
-			if group.Name != baseOnGroup {
-				continue
+			if group.Name == baseOnGroup {
+				groupIndex = groupIdx
+				break
 			}
-
-			groupIndex = groupIdx
 		}
 
 		if groupIndex < 0 {

--- a/cmd/nodes_add.go
+++ b/cmd/nodes_add.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	baseOneNode    string
+	baseOnNode     string
 	startNode      bool
 	resultsOutPath string
 	count          int
@@ -45,7 +45,7 @@ var nodesAddCmd = &cobra.Command{
 		for i := 0; i < count; i++ {
 			i := i + 1
 			eg.Go(func() error {
-				newNodeSet, err := nodesAddNode(*networkState, i, baseOneNode)
+				newNodeSet, err := nodesAddNode(*networkState, i, baseOnNode)
 				if err != nil {
 					return fmt.Errorf("failed to add new node: %w", err)
 				}
@@ -103,7 +103,7 @@ func init() {
 		true,
 		"Allows to configure whether or not the new node set should automatically start",
 	)
-	nodesAddCmd.PersistentFlags().StringVar(&baseOneNode,
+	nodesAddCmd.PersistentFlags().StringVar(&baseOnNode,
 		"base-on",
 		"",
 		"Name of the node set that the new node set should be based on",
@@ -123,7 +123,7 @@ func init() {
 	)
 }
 
-func nodesAddNode(state state.NetworkState, index int, baseOneNode string) (*types.NodeSet, error) {
+func nodesAddNode(state state.NetworkState, index int, baseOnNode string) (*types.NodeSet, error) {
 	nomadClient, err := nomad.NewClient(nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create nomad client: %w", err)
@@ -144,7 +144,7 @@ func nodesAddNode(state state.NetworkState, index int, baseOneNode string) (*typ
 		return nil, err
 	}
 
-	nodeSet, err := state.GeneratedServices.GetNodeSet(baseOneNode)
+	nodeSet, err := state.GeneratedServices.GetNodeSet(baseOnNode)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/nodes_add.go
+++ b/cmd/nodes_add.go
@@ -16,6 +16,7 @@ import (
 
 var (
 	baseOnNode     string
+	baseOnGroup    string
 	startNode      bool
 	resultsOutPath string
 	count          int
@@ -45,7 +46,7 @@ var nodesAddCmd = &cobra.Command{
 		for i := 0; i < count; i++ {
 			i := i + 1
 			eg.Go(func() error {
-				newNodeSet, err := nodesAddNode(*networkState, i, baseOnNode)
+				newNodeSet, err := nodesAddNode(*networkState, i, baseOnNode, baseOnGroup)
 				if err != nil {
 					return fmt.Errorf("failed to add new node: %w", err)
 				}
@@ -108,6 +109,11 @@ func init() {
 		"",
 		"Name of the node set that the new node set should be based on",
 	)
+	nodesAddCmd.PersistentFlags().StringVar(&baseOnGroup,
+		"base-on-group",
+		"",
+		"Name of the group that the new node set should be based on",
+	)
 	nodesAddCmd.MarkFlagRequired("base-on")
 
 	nodesAddCmd.PersistentFlags().IntVar(&count,
@@ -123,7 +129,11 @@ func init() {
 	)
 }
 
-func nodesAddNode(state state.NetworkState, index int, baseOnNode string) (*types.NodeSet, error) {
+func nodesAddNode(state state.NetworkState, index int, baseOnNode, baseOnGroup string) (*types.NodeSet, error) {
+	if baseOnNode != "" && baseOnGroup != "" {
+		return nil, fmt.Errorf("provide either value for --base-on or --base-on-group, not both values")
+	}
+
 	nomadClient, err := nomad.NewClient(nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create nomad client: %w", err)
@@ -144,7 +154,17 @@ func nodesAddNode(state state.NetworkState, index int, baseOnNode string) (*type
 		return nil, err
 	}
 
-	nodeSet, err := state.GeneratedServices.GetNodeSet(baseOnNode)
+	var nodeSet *types.NodeSet
+	if baseOnNode != "" {
+		nodeSet, err = state.GeneratedServices.GetNodeSet(baseOnNode)
+	} else {
+		indexes, err := computeNodeIndexes(state, baseOnGroup)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compute indexes for new node set: %w", err)
+		}
+		nodeSet, err = gen.InitiateSingleNodeSet(baseOnGroup, indexes.abs, indexes.group, indexes.relative)
+	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -169,4 +189,35 @@ func nodesAddNode(state state.NetworkState, index int, baseOnNode string) (*type
 	}
 
 	return newNodeSet, nil
+}
+
+type nsIndex struct {
+	abs      int
+	group    int
+	relative int
+}
+
+// computeNodeIndexes computes indexes to initiate new node set.
+func computeNodeIndexes(state state.NetworkState, groupName string) (*nsIndex, error) {
+	for groupIdx, group := range state.Config.Network.Nodes {
+		if group.Name != groupName {
+			continue
+		}
+
+		result := &nsIndex{
+			group:    groupIdx,
+			abs:      len(state.GeneratedServices.NodeSets),
+			relative: 0,
+		}
+
+		for _, ns := range state.GeneratedServices.NodeSets {
+			if ns.GroupName == groupName {
+				result.relative++
+			}
+		}
+
+		return result, nil
+	}
+
+	return nil, fmt.Errorf("the group for %s not found", groupName)
 }

--- a/cmd/nodes_add.go
+++ b/cmd/nodes_add.go
@@ -129,7 +129,12 @@ func nodesAddNode(state state.NetworkState, index int, baseOneNode string) (*typ
 		return nil, fmt.Errorf("failed to create nomad client: %w", err)
 	}
 
-	nomadRunner, err := nomad.NewJobRunner(nomadClient, *state.Config.VegaCapsuleBinary, state.Config.LogsDir())
+	capsuleBinary := ""
+	if state.Config.VegaCapsuleBinary != nil {
+		capsuleBinary = *state.Config.VegaCapsuleBinary
+	}
+
+	nomadRunner, err := nomad.NewJobRunner(nomadClient, capsuleBinary, state.Config.LogsDir())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create job runner: %w", err)
 	}

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -194,17 +194,16 @@ func (g *Generator) AddNodeSet(absoluteIndex, relativeIndex, groupIndex int, nc 
 
 	co, err := newConfigOverride(g, *cnc)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create new config override: %w", err)
 	}
 
 	if err := co.Overwrite(*cnc, *initNodeSet, fc); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to overwrite config: %w", err)
 	}
 
 	if err := utils.CopyFile(ns.Tendermint.GenesisFilePath, initNodeSet.Tendermint.GenesisFilePath); err != nil {
 		return nil, fmt.Errorf("failed to copy genesis file: %w", err)
 	}
-
 	log.Printf("Added new node set with id %q", initNodeSet.Name)
 
 	return initNodeSet, nil

--- a/generator/initiate.go
+++ b/generator/initiate.go
@@ -139,39 +139,6 @@ func (g *Generator) initiateNodeSets() (*nodeSets, error) {
 	}, nil
 }
 
-func (g *Generator) InitiateSingleNodeSet(nodeGroupName string, absIndex, groupIndex, relativeIndex int) (*types.NodeSet, error) {
-	var (
-		nc  *config.NodeConfig
-		err error
-	)
-
-	for _, n := range g.conf.Network.Nodes {
-		if n.Name != nodeGroupName {
-			continue
-		}
-
-		nc, err = n.Clone()
-		if err != nil {
-			return nil, fmt.Errorf("failed to clone the %s node config: %w", nodeGroupName, err)
-		}
-		continue
-	}
-
-	preGenJobs, err := g.startPreGenerateJobs(*nc, absIndex)
-	if err != nil {
-		return nil, fmt.Errorf("failed to start pregenerated jobs: %w", err)
-	}
-
-	nodeSet, err := g.initiateNodeSet(absIndex, relativeIndex, groupIndex, *nc)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initiate node set: %w", err)
-	}
-
-	nodeSet.PreGenerateJobs = preGenJobs
-
-	return nodeSet, nil
-}
-
 func (g *Generator) initAndConfigureFaucet(conf *config.FaucetConfig) (*types.Faucet, error) {
 	initFaucet, err := g.faucetGen.InitiateAndConfigure(conf)
 	if err != nil {

--- a/generator/initiate.go
+++ b/generator/initiate.go
@@ -139,6 +139,39 @@ func (g *Generator) initiateNodeSets() (*nodeSets, error) {
 	}, nil
 }
 
+func (g *Generator) InitiateSingleNodeSet(nodeGroupName string, absIndex, groupIndex, relativeIndex int) (*types.NodeSet, error) {
+	var (
+		nc  *config.NodeConfig
+		err error
+	)
+
+	for _, n := range g.conf.Network.Nodes {
+		if n.Name != nodeGroupName {
+			continue
+		}
+
+		nc, err = n.Clone()
+		if err != nil {
+			return nil, fmt.Errorf("failed to clone the %s node config: %w", nodeGroupName, err)
+		}
+		continue
+	}
+
+	preGenJobs, err := g.startPreGenerateJobs(*nc, absIndex)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start pregenerated jobs: %w", err)
+	}
+
+	nodeSet, err := g.initiateNodeSet(absIndex, relativeIndex, groupIndex, *nc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initiate node set: %w", err)
+	}
+
+	nodeSet.PreGenerateJobs = preGenJobs
+
+	return nodeSet, nil
+}
+
 func (g *Generator) initAndConfigureFaucet(conf *config.FaucetConfig) (*types.Faucet, error) {
 	initFaucet, err := g.faucetGen.InitiateAndConfigure(conf)
 	if err != nil {


### PR DESCRIPTION
closes https://github.com/vegaprotocol/devops-infra/issues/1856 .

We cannot remove all nodes from the particular group and then start a node from it because we do not have any node available for the `--base-on` flag.  So I have added the `--base-on-group` flag, which does not require the node in a particular group. 

This change adds the ability to start the node in the particular group even if no node is running.

I have tested this with the following code: https://github.com/vegaprotocol/devopstools/pull/41