### PR TITLE
fix: respect --do-not-stop-on-failure flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [384](https://github.com/vegaprotocol/vegacapsule/issues/384) Add command for stoping/starting a specific job
 
 ### 🐛 Fixes
+- [394](https://github.com/vegaprotocol/vegacapsule/pull/394) Respect the `--do-not-stop-on-failure` flag
 
 ## v0.5.1
 

--- a/cmd/nodes_start.go
+++ b/cmd/nodes_start.go
@@ -63,6 +63,11 @@ func init() {
 		"",
 		"Path of Vega binary to be used to start the node",
 	)
+	nodesStartCmd.PersistentFlags().BoolVar(&doNotStopAllJobsOnFailure,
+		"do-not-stop-on-failure",
+		false,
+		"Do not stop partially running network when failed to start",
+	)
 	nodesStartCmd.MarkFlagRequired("name")
 }
 
@@ -96,7 +101,7 @@ func nodesStartNode(ctx context.Context, nodeSet *types.NodeSet, conf *config.Co
 		}
 	}
 
-	res, err := nomadRunner.RunNodeSets(ctx, []types.NodeSet{*nodeSet})
+	res, err := nomadRunner.RunNodeSets(ctx, []types.NodeSet{*nodeSet}, !doNotStopAllJobsOnFailure)
 	if err != nil {
 		return "", fmt.Errorf("failed to start nomad node set %q : %w", nodeSet.Name, err)
 	}


### PR DESCRIPTION
There was a bug that jobs were stopped when they failed even when the `--do-not-stop-on-failure` flag was present. It was hard to debug when binary did not produced any log or it failed immediately 