### PR TITLE
feat: fix detecting for image pull during startup

### DIFF
--- a/nomad/client_allocs.go
+++ b/nomad/client_allocs.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	downloadingImageMessage      = "downloading image"
+	imagePullProgressMessage     = "image pull progress"
 	downloadingArtifactsMessage  = "downloading artifacts"
 	taskReceivedMessage          = "received by client"
 	buildingTaskDirectoryMessage = "building task directory"
@@ -69,7 +70,7 @@ func (ai allocationInfo) lastEventMessageContains(text string) bool {
 }
 
 func (ai allocationInfo) downloadingImage() bool {
-	return ai.lastEventMessageContains(downloadingImageMessage)
+	return ai.lastEventMessageContains(downloadingImageMessage) || ai.lastEventMessageContains(imagePullProgressMessage)
 }
 
 func (ai allocationInfo) downloadingArtifacts() bool {


### PR DESCRIPTION
Change for this workflow:

```
2023/09/26 10:51:38 Job "ganache-1" has timed out output: Task: "ganache-1", State: "pending", Events: "Received: Task received by client -> Task Setup: Building Task Directory -> Driver: Downloading image -> Driver: Docker image pull progress: Pulled 17/17 (133.1MiB/133.1MiB) layers: 0 waiting/0 pulling"
```